### PR TITLE
fakestorage: add support for Crc32c checksum of object content.

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -21,6 +21,8 @@ type Object struct {
 	BucketName string `json:"-"`
 	Name       string `json:"name"`
 	Content    []byte `json:"-"`
+	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
+	Crc32c 	   string `json:"crc32c,omitempty"`
 }
 
 func (o *Object) id() string {
@@ -181,6 +183,7 @@ func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 		BucketName: dstBucket,
 		Name:       vars["destinationObject"],
 		Content:    append([]byte(nil), obj.Content...),
+		Crc32c: 	obj.Crc32c,
 	}
 	s.CreateObject(newObject)
 	w.Header().Set("Content-Type", "application/json")

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -22,7 +22,7 @@ type Object struct {
 	Name       string `json:"name"`
 	Content    []byte `json:"-"`
 	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
-	Crc32c 	   string `json:"crc32c,omitempty"`
+	Crc32c string `json:"crc32c,omitempty"`
 }
 
 func (o *Object) id() string {
@@ -183,7 +183,7 @@ func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 		BucketName: dstBucket,
 		Name:       vars["destinationObject"],
 		Content:    append([]byte(nil), obj.Content...),
-		Crc32c: 	obj.Crc32c,
+		Crc32c:     obj.Crc32c,
 	}
 	s.CreateObject(newObject)
 	w.Header().Set("Content-Type", "application/json")

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -10,10 +10,11 @@ import (
 	"reflect"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"encoding/binary"
-	"google.golang.org/api/iterator"
 	"hash/crc32"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 )
 
 func uint32ToBytes(ui uint32) []byte {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -6,12 +6,11 @@ package fakestorage
 
 import (
 	"context"
+	"encoding/binary"
+	"hash/crc32"
 	"io/ioutil"
 	"reflect"
 	"testing"
-
-	"encoding/binary"
-	"hash/crc32"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"encoding/binary"
 	"google.golang.org/api/iterator"
 	"hash/crc32"
-	"encoding/binary"
 )
 
 func uint32ToBytes(ui uint32) []byte {
@@ -400,7 +400,7 @@ func TestServiceClientRewriteObject(t *testing.T) {
 		testCase   string
 		bucketName string
 		objectName string
-		crc32c	   uint32
+		crc32c     uint32
 	}{
 		{
 			"same bucket",

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -1,6 +1,8 @@
 package fakestorage
 
-import "sort"
+import (
+	"sort"
+)
 
 type listResponse struct {
 	Kind     string        `json:"kind"`
@@ -52,7 +54,11 @@ type objectResponse struct {
 	ID     string `json:"id"`
 	Bucket string `json:"bucket"`
 	Size   int64  `json:"size,string"`
+	// Crc32c: CRC32c checksum, same as in google storage client code
+	Crc32c string `json:"crc32c,omitempty"`
+
 }
+
 
 func newObjectResponse(obj Object) objectResponse {
 	return objectResponse{
@@ -61,6 +67,7 @@ func newObjectResponse(obj Object) objectResponse {
 		Bucket: obj.BucketName,
 		Name:   obj.Name,
 		Size:   int64(len(obj.Content)),
+		Crc32c: obj.Crc32c,
 	}
 }
 

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -56,9 +56,7 @@ type objectResponse struct {
 	Size   int64  `json:"size,string"`
 	// Crc32c: CRC32c checksum, same as in google storage client code
 	Crc32c string `json:"crc32c,omitempty"`
-
 }
-
 
 func newObjectResponse(obj Object) objectResponse {
 	return objectResponse{

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -16,9 +16,9 @@ import (
 	"strconv"
 	"strings"
 
+	"encoding/base64"
 	"github.com/gorilla/mux"
 	"hash/crc32"
-	"encoding/base64"
 )
 
 type multipartMetadata struct {

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -17,8 +17,9 @@ import (
 	"strings"
 
 	"encoding/base64"
-	"github.com/gorilla/mux"
 	"hash/crc32"
+
+	"github.com/gorilla/mux"
 )
 
 type multipartMetadata struct {


### PR DESCRIPTION
Hi, This change makes it possible to test client code that is using Crc32c checksum checks.

Thanks for creating this server by the way, works great for my tests!