### PR TITLE
Add filesystem backend

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -18,17 +18,19 @@ import (
 func (s *Server) CreateBucket(name string) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	if _, ok := s.buckets[name]; !ok {
-		s.buckets[name] = nil
+	err := s.backend.CreateBucket(name)
+	if err != nil {
+		panic(err)
 	}
 }
 
 func (s *Server) listBuckets(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	bucketNames := make([]string, 0, len(s.buckets))
-	for name := range s.buckets {
-		bucketNames = append(bucketNames, name)
+
+	bucketNames, err := s.backend.ListBuckets()
+	if err != nil {
+		panic(err)
 	}
 	resp := newListBucketsResponse(bucketNames)
 	json.NewEncoder(w).Encode(resp)
@@ -39,7 +41,7 @@ func (s *Server) getBucket(w http.ResponseWriter, r *http.Request) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	encoder := json.NewEncoder(w)
-	if _, ok := s.buckets[bucketName]; !ok {
+	if err := s.backend.GetBucket(bucketName); err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		err := newErrorResponse(http.StatusNotFound, "Not found", nil)
 		encoder.Encode(err)

--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -30,7 +30,8 @@ func (s *Server) listBuckets(w http.ResponseWriter, r *http.Request) {
 
 	bucketNames, err := s.backend.ListBuckets()
 	if err != nil {
-		panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	resp := newListBucketsResponse(bucketNames)
 	json.NewEncoder(w).Encode(resp)

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -51,15 +51,14 @@ func (o *objectList) Swap(i int, j int) {
 func (s *Server) CreateObject(obj Object) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	s.createObject(obj)
-}
-
-func (s *Server) createObject(obj Object) {
-	err := s.backend.CreateObject(backend.Object{BucketName: obj.BucketName, Name: obj.Name, Content: obj.Content})
+	err := s.createObject(obj)
 	if err != nil {
-		// TODO: handle errors better
 		panic(err)
 	}
+}
+
+func (s *Server) createObject(obj Object) error {
+	return s.backend.CreateObject(backend.Object{BucketName: obj.BucketName, Name: obj.Name, Content: obj.Content})
 }
 
 // ListObjects returns a sorted list of objects that match the given criteria,

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -58,7 +58,7 @@ func (s *Server) CreateObject(obj Object) {
 }
 
 func (s *Server) createObject(obj Object) error {
-	return s.backend.CreateObject(backend.Object{BucketName: obj.BucketName, Name: obj.Name, Content: obj.Content})
+	return s.backend.CreateObject(toBackendObjects([]Object{obj})[0])
 }
 
 // ListObjects returns a sorted list of objects that match the given criteria,
@@ -103,6 +103,7 @@ func toBackendObjects(objects []Object) []backend.Object {
 			BucketName: o.BucketName,
 			Name:       o.Name,
 			Content:    o.Content,
+			Crc32c:     o.Crc32c,
 		})
 	}
 	return backendObjects
@@ -115,7 +116,7 @@ func fromBackendObjects(objects []backend.Object) []Object {
 			BucketName: o.BucketName,
 			Name:       o.Name,
 			Content:    o.Content,
-			Crc32c:     encodedCrc32cChecksum(o.Content),
+			Crc32c:     o.Crc32c,
 		})
 	}
 	return backendObjects

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -62,7 +62,11 @@ func (s *Server) simpleUpload(bucketName string, w http.ResponseWriter, r *http.
 		return
 	}
 	obj := Object{BucketName: bucketName, Name: name, Content: data, Crc32c: encodedCrc32cChecksum(data)}
-	s.createObject(obj)
+	err = s.createObject(obj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(obj)
 }
@@ -111,7 +115,11 @@ func (s *Server) multipartUpload(bucketName string, w http.ResponseWriter, r *ht
 		return
 	}
 	obj := Object{BucketName: bucketName, Name: metadata.Name, Content: content, Crc32c: encodedCrc32cChecksum(content)}
-	s.createObject(obj)
+	err = s.createObject(obj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(obj)
 }
@@ -166,7 +174,11 @@ func (s *Server) uploadFileContent(w http.ResponseWriter, r *http.Request) {
 	}
 	if commit {
 		delete(s.uploads, uploadID)
-		s.createObject(obj)
+		err = s.createObject(obj)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	} else {
 		status = http.StatusOK
 		w.Header().Set("X-Http-Status-Code-Override", "308")

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -30,7 +30,7 @@ func (s *Server) insertObject(w http.ResponseWriter, r *http.Request) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	bucketName := mux.Vars(r)["bucketName"]
-	if _, ok := s.buckets[bucketName]; !ok {
+	if err := s.backend.GetBucket(bucketName); err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		err := newErrorResponse(http.StatusNotFound, "Not found", nil)
 		json.NewEncoder(w).Encode(err)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -53,8 +53,9 @@ func shouldError(t *testing.T, err error, message string) {
 func TestObjectCRUD(t *testing.T) {
 	const bucketName = "prod-bucket"
 	const objectName = "video/hi-res/best_video_1080p.mp4"
-	var content1 = []byte("content1")
-	var content2 = []byte("content2")
+	content1 := []byte("content1")
+	const crc1 = "crc1"
+	content2 := []byte("content2")
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		// Get in non-existent case
 		_, err := storage.GetObject(bucketName, objectName)
@@ -63,7 +64,7 @@ func TestObjectCRUD(t *testing.T) {
 		err = storage.DeleteObject(bucketName, objectName)
 		shouldError(t, err, "object successfully delete before being created")
 		// Create in non-existent case
-		noError(t, storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1}))
+		noError(t, storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1, Crc32c: crc1}))
 		// Get in existent case
 		obj, err := storage.GetObject(bucketName, objectName)
 		noError(t, err)
@@ -72,6 +73,9 @@ func TestObjectCRUD(t *testing.T) {
 		}
 		if obj.Name != objectName {
 			t.Errorf("wrong object name\n want %q\ngot  %q", objectName, obj.Name)
+		}
+		if obj.Crc32c != crc1 {
+			t.Errorf("wrong crc\n want %q\ngot  %q", crc1, obj.Crc32c)
 		}
 		if !bytes.Equal(obj.Content, content1) {
 			t.Errorf("wrong object content\n want %q\ngot  %q", content1, obj.Content)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,117 @@
+package backend
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func makeStorageBackends(t *testing.T) map[string]Storage {
+	return map[string]Storage{
+		"memory": NewStorageMemory(nil),
+	}
+}
+
+func testForStorageBackends(t *testing.T, test func(t *testing.T, storage Storage)) {
+	for backendName, storage := range makeStorageBackends(t) {
+		t.Run(fmt.Sprintf("storage backend %s", backendName), func(t *testing.T) {
+			test(t, storage)
+		})
+	}
+}
+
+func TestObjectCRUD(t *testing.T) {
+	const bucketName = "prod-bucket"
+	const objectName = "video/hi-res/best_video_1080p.mp4"
+	var content1 = []byte("content1")
+	var content2 = []byte("content2")
+	testForStorageBackends(t, func(t *testing.T, storage Storage) {
+		// Get in non-existent case
+		_, err := storage.GetObject(bucketName, objectName)
+		if err == nil {
+			t.Fatal("object found before being created")
+		}
+		// Delete in non-existent case
+		err = storage.DeleteObject(bucketName, objectName)
+		if err == nil {
+			t.Fatal("object successfully delete before being created")
+		}
+		// Create in non-existent case
+		err = storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Get in existent case
+		obj, err := storage.GetObject(bucketName, objectName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obj.BucketName != bucketName {
+			t.Errorf("wrong bucket name\nwant %q\ngot  %q", bucketName, obj.BucketName)
+		}
+		if obj.Name != objectName {
+			t.Errorf("wrong object name\n want %q\ngot  %q", objectName, obj.Name)
+		}
+		if !bytes.Equal(obj.Content, content1) {
+			t.Errorf("wrong object content\n want %q\ngot  %q", content1, obj.Content)
+		}
+		// Create (update) in existent case
+		err = storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content2})
+		if err != nil {
+			t.Fatal(err)
+		}
+		obj, err = storage.GetObject(bucketName, objectName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obj.BucketName != bucketName {
+			t.Errorf("wrong bucket name\nwant %q\ngot  %q", bucketName, obj.BucketName)
+		}
+		if obj.Name != objectName {
+			t.Errorf("wrong object name\n want %q\ngot  %q", objectName, obj.Name)
+		}
+		if !bytes.Equal(obj.Content, content2) {
+			t.Errorf("wrong object content\n want %q\ngot  %q", content2, obj.Content)
+		}
+		// Delete in existent case
+		err = storage.DeleteObject(bucketName, objectName)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestBucketCreateGetList(t *testing.T) {
+	const bucketName = "prod-bucket"
+	testForStorageBackends(t, func(t *testing.T, storage Storage) {
+		err := storage.GetBucket(bucketName)
+		if err == nil {
+			t.Fatal("bucket exists before being created")
+		}
+		buckets, err := storage.ListBuckets()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(buckets) != 0 {
+			t.Fatalf("more than zero buckets found: %d", len(buckets))
+		}
+		err = storage.CreateBucket(bucketName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = storage.GetBucket(bucketName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buckets, err = storage.ListBuckets()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(buckets) != 1 {
+			t.Fatalf("one bucket not found after creating it, found: %d", len(buckets))
+		}
+		if buckets[0] != bucketName {
+			t.Fatalf("wrong bucket name; expected %s, got %s", bucketName, buckets[0])
+		}
+	})
+}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -38,6 +38,18 @@ func testForStorageBackends(t *testing.T, test func(t *testing.T, storage Storag
 	}
 }
 
+func noError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func shouldError(t *testing.T, err error, message string) {
+	if err == nil {
+		t.Fatal(message)
+	}
+}
+
 func TestObjectCRUD(t *testing.T) {
 	const bucketName = "prod-bucket"
 	const objectName = "video/hi-res/best_video_1080p.mp4"
@@ -46,24 +58,15 @@ func TestObjectCRUD(t *testing.T) {
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		// Get in non-existent case
 		_, err := storage.GetObject(bucketName, objectName)
-		if err == nil {
-			t.Fatal("object found before being created")
-		}
+		shouldError(t, err, "object found before being created")
 		// Delete in non-existent case
 		err = storage.DeleteObject(bucketName, objectName)
-		if err == nil {
-			t.Fatal("object successfully delete before being created")
-		}
+		shouldError(t, err, "object successfully delete before being created")
 		// Create in non-existent case
-		err = storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1})
-		if err != nil {
-			t.Fatal(err)
-		}
+		noError(t, storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1}))
 		// Get in existent case
 		obj, err := storage.GetObject(bucketName, objectName)
-		if err != nil {
-			t.Fatal(err)
-		}
+		noError(t, err)
 		if obj.BucketName != bucketName {
 			t.Errorf("wrong bucket name\nwant %q\ngot  %q", bucketName, obj.BucketName)
 		}
@@ -75,13 +78,9 @@ func TestObjectCRUD(t *testing.T) {
 		}
 		// Create (update) in existent case
 		err = storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content2})
-		if err != nil {
-			t.Fatal(err)
-		}
+		noError(t, err)
 		obj, err = storage.GetObject(bucketName, objectName)
-		if err != nil {
-			t.Fatal(err)
-		}
+		noError(t, err)
 		if obj.BucketName != bucketName {
 			t.Errorf("wrong bucket name\nwant %q\ngot  %q", bucketName, obj.BucketName)
 		}
@@ -93,9 +92,7 @@ func TestObjectCRUD(t *testing.T) {
 		}
 		// Delete in existent case
 		err = storage.DeleteObject(bucketName, objectName)
-		if err != nil {
-			t.Fatal(err)
-		}
+		noError(t, err)
 	})
 }
 

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -22,7 +22,7 @@ type StorageFS struct {
 	rootDir string
 }
 
-// NewStorageMemory creates an instance of StorageMemory
+// NewStorageFS creates an instance of StorageMemory
 func NewStorageFS(objects []Object, rootDir string) (Storage, error) {
 	if !strings.HasSuffix(rootDir, "/") {
 		rootDir += "/"
@@ -66,10 +66,7 @@ func (s *StorageFS) ListBuckets() ([]string, error) {
 // GetBucket checks if a bucket exists
 func (s *StorageFS) GetBucket(name string) error {
 	_, err := os.Stat(filepath.Join(s.rootDir, url.PathEscape(name)))
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // CreateObject stores an object

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -1,0 +1,127 @@
+package backend
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// StorageFS is an implementation of the backend storage that stores data on disk
+// The layout is the following:
+// - rootDir
+//   |- bucket1
+//   \- bucket2
+//     |- object1
+//     \- object2
+// Bucket and object names are url path escaped, so there's no special meaning of forward slashes.
+type StorageFS struct {
+	rootDir string
+}
+
+// NewStorageMemory creates an instance of StorageMemory
+func NewStorageFS(objects []Object, rootDir string) (Storage, error) {
+	if !strings.HasSuffix(rootDir, "/") {
+		rootDir += "/"
+	}
+	s := &StorageFS{
+		rootDir: rootDir,
+	}
+	for _, o := range objects {
+		err := s.CreateObject(o)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// CreateBucket creates a bucket
+func (s *StorageFS) CreateBucket(name string) error {
+	return os.MkdirAll(filepath.Join(s.rootDir, url.PathEscape(name)), 0700)
+}
+
+// ListBuckets lists buckets
+func (s *StorageFS) ListBuckets() ([]string, error) {
+	infos, err := ioutil.ReadDir(s.rootDir)
+	if err != nil {
+		return nil, err
+	}
+	buckets := []string{}
+	for _, info := range infos {
+		if info.IsDir() {
+			unescaped, err := url.PathUnescape(info.Name())
+			if err != nil {
+				return nil, fmt.Errorf("failed to unescape object name %s: %s", info.Name(), err)
+			}
+			buckets = append(buckets, unescaped)
+		}
+	}
+	return buckets, nil
+}
+
+// GetBucket checks if a bucket exists
+func (s *StorageFS) GetBucket(name string) error {
+	_, err := os.Stat(filepath.Join(s.rootDir, url.PathEscape(name)))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateObject stores an object
+func (s *StorageFS) CreateObject(obj Object) error {
+	err := s.CreateBucket(obj.BucketName)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)), obj.Content, 0664)
+}
+
+// ListObjects lists the objects in a given bucket with a given prefix and delimeter
+func (s *StorageFS) ListObjects(bucketName string) ([]Object, error) {
+	infos, err := ioutil.ReadDir(path.Join(s.rootDir, url.PathEscape(bucketName)))
+	if err != nil {
+		return nil, err
+	}
+	objects := []Object{}
+	for _, info := range infos {
+		if info.IsDir() {
+			unescaped, err := url.PathUnescape(info.Name())
+			if err != nil {
+				return nil, fmt.Errorf("failed to unescape object name %s: %s", info.Name(), err)
+			}
+			object, err := s.GetObject(bucketName, unescaped)
+			if err != nil {
+				return nil, err
+			}
+			objects = append(objects, object)
+		}
+	}
+	return objects, nil
+}
+
+// GetObject get an object by bucket and name
+func (s *StorageFS) GetObject(bucketName, objectName string) (Object, error) {
+	content, err := ioutil.ReadFile(filepath.Join(s.rootDir, url.PathEscape(bucketName), url.PathEscape(objectName)))
+	if err != nil {
+		return Object{}, err
+	}
+
+	return Object{
+		Name:       objectName,
+		BucketName: bucketName,
+		Content:    content,
+	}, nil
+}
+
+// DeleteObject deletes an object by bucket and name
+func (s *StorageFS) DeleteObject(bucketName, objectName string) error {
+	if objectName == "" {
+		return fmt.Errorf("can't delete object with empty name")
+	}
+	return os.Remove(filepath.Join(s.rootDir, url.PathEscape(bucketName), url.PathEscape(objectName)))
+}

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -3,8 +3,6 @@ package backend
 import (
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 	"sync"
 )
 
@@ -89,36 +87,14 @@ func (s *StorageMemory) findObject(obj Object) int {
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and delimeter
-func (s *StorageMemory) ListObjects(bucketName, prefix, delimiter string) ([]Object, []string, error) {
+func (s *StorageMemory) ListObjects(bucketName string) ([]Object, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	objects, ok := s.buckets[bucketName]
 	if !ok {
-		return nil, nil, errors.New("bucket not found")
+		return nil, errors.New("bucket not found")
 	}
-	olist := objectList(objects)
-	sort.Sort(&olist)
-	var (
-		respObjects  []Object
-		respPrefixes []string
-	)
-	prefixes := make(map[string]bool)
-	for _, obj := range olist {
-		if strings.HasPrefix(obj.Name, prefix) {
-			objName := strings.Replace(obj.Name, prefix, "", 1)
-			delimPos := strings.Index(objName, delimiter)
-			if delimiter != "" && delimPos > -1 {
-				prefixes[obj.Name[:len(prefix)+delimPos+1]] = true
-			} else {
-				respObjects = append(respObjects, obj)
-			}
-		}
-	}
-	for p := range prefixes {
-		respPrefixes = append(respPrefixes, p)
-	}
-	sort.Strings(respPrefixes)
-	return respObjects, respPrefixes, nil
+	return objects, nil
 }
 
 // GetObject get an object by bucket and name

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -1,0 +1,147 @@
+package backend
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// StorageMemory is an implementation of the backend storage that stores data in memory
+type StorageMemory struct {
+	buckets map[string][]Object
+	mtx     sync.RWMutex
+}
+
+// NewStorageMemory creates an instance of StorageMemory
+func NewStorageMemory(objects []Object) Storage {
+	s := &StorageMemory{
+		buckets: make(map[string][]Object),
+	}
+	for _, o := range objects {
+		s.buckets[o.BucketName] = append(s.buckets[o.BucketName], o)
+	}
+	return s
+}
+
+// CreateBucket creates a bucket
+func (s *StorageMemory) CreateBucket(name string) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if _, ok := s.buckets[name]; !ok {
+		s.buckets[name] = nil
+	}
+	return nil
+}
+
+// ListBuckets lists buckets
+func (s *StorageMemory) ListBuckets() ([]string, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	buckets := []string{}
+	for bucket := range s.buckets {
+		buckets = append(buckets, bucket)
+	}
+	return buckets, nil
+}
+
+// GetBucket checks if a bucket exists
+func (s *StorageMemory) GetBucket(name string) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if _, ok := s.buckets[name]; !ok {
+		return fmt.Errorf("No bucket named %s", name)
+	}
+	return nil
+}
+
+// CreateObject stores an object
+func (s *StorageMemory) CreateObject(obj Object) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.createObject(obj)
+	return nil
+}
+
+func (s *StorageMemory) createObject(obj Object) {
+	index := s.findObject(obj)
+	if index < 0 {
+		s.buckets[obj.BucketName] = append(s.buckets[obj.BucketName], obj)
+	} else {
+		s.buckets[obj.BucketName][index] = obj
+	}
+}
+
+// findObject looks for an object in its bucket and return the index where it
+// was found, or -1 if the object doesn't exist.
+//
+// It doesn't lock the mutex, callers must lock the mutex before calling this
+// method.
+func (s *StorageMemory) findObject(obj Object) int {
+	for i, o := range s.buckets[obj.BucketName] {
+		if obj.ID() == o.ID() {
+			return i
+		}
+	}
+	return -1
+}
+
+// ListObjects lists the objects in a given bucket with a given prefix and delimeter
+func (s *StorageMemory) ListObjects(bucketName, prefix, delimiter string) ([]Object, []string, error) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	objects, ok := s.buckets[bucketName]
+	if !ok {
+		return nil, nil, errors.New("bucket not found")
+	}
+	olist := objectList(objects)
+	sort.Sort(&olist)
+	var (
+		respObjects  []Object
+		respPrefixes []string
+	)
+	prefixes := make(map[string]bool)
+	for _, obj := range olist {
+		if strings.HasPrefix(obj.Name, prefix) {
+			objName := strings.Replace(obj.Name, prefix, "", 1)
+			delimPos := strings.Index(objName, delimiter)
+			if delimiter != "" && delimPos > -1 {
+				prefixes[obj.Name[:len(prefix)+delimPos+1]] = true
+			} else {
+				respObjects = append(respObjects, obj)
+			}
+		}
+	}
+	for p := range prefixes {
+		respPrefixes = append(respPrefixes, p)
+	}
+	sort.Strings(respPrefixes)
+	return respObjects, respPrefixes, nil
+}
+
+// GetObject get an object by bucket and name
+func (s *StorageMemory) GetObject(bucketName, objectName string) (Object, error) {
+	obj := Object{BucketName: bucketName, Name: objectName}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	index := s.findObject(obj)
+	if index < 0 {
+		return obj, errors.New("object not found")
+	}
+	return s.buckets[bucketName][index], nil
+}
+
+// DeleteObject deletes an object by bucket and name
+func (s *StorageMemory) DeleteObject(bucketName, objectName string) error {
+	obj := Object{BucketName: bucketName, Name: objectName}
+	index := s.findObject(obj)
+	if index < 0 {
+		return fmt.Errorf("No such object in bucket %s: %s", bucketName, objectName)
+	}
+	bucket := s.buckets[obj.BucketName]
+	bucket[index] = bucket[len(bucket)-1]
+	s.buckets[obj.BucketName] = bucket[:len(bucket)-1]
+	return nil
+}

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -59,17 +59,14 @@ func (s *StorageMemory) GetBucket(name string) error {
 func (s *StorageMemory) CreateObject(obj Object) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	s.createObject(obj)
-	return nil
-}
 
-func (s *StorageMemory) createObject(obj Object) {
 	index := s.findObject(obj)
 	if index < 0 {
 		s.buckets[obj.BucketName] = append(s.buckets[obj.BucketName], obj)
 	} else {
 		s.buckets[obj.BucketName][index] = obj
 	}
+	return nil
 }
 
 // findObject looks for an object in its bucket and return the index where it

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -2,28 +2,11 @@ package backend
 
 // Object represents the object that is stored within the fake server.
 type Object struct {
-	BucketName string `json:"-"`
-	Name       string `json:"name"`
-	Content    []byte `json:"-"`
-	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
-	Crc32c string `json:"crc32c,omitempty"`
+	BucketName string
+	Name       string
+	Content    []byte
 }
 
 func (o *Object) ID() string {
 	return o.BucketName + "/" + o.Name
-}
-
-type objectList []Object
-
-func (o objectList) Len() int {
-	return len(o)
-}
-
-func (o objectList) Less(i int, j int) bool {
-	return o[i].Name < o[j].Name
-}
-
-func (o *objectList) Swap(i int, j int) {
-	d := *o
-	d[i], d[j] = d[j], d[i]
 }

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -1,0 +1,29 @@
+package backend
+
+// Object represents the object that is stored within the fake server.
+type Object struct {
+	BucketName string `json:"-"`
+	Name       string `json:"name"`
+	Content    []byte `json:"-"`
+	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
+	Crc32c string `json:"crc32c,omitempty"`
+}
+
+func (o *Object) ID() string {
+	return o.BucketName + "/" + o.Name
+}
+
+type objectList []Object
+
+func (o objectList) Len() int {
+	return len(o)
+}
+
+func (o objectList) Less(i int, j int) bool {
+	return o[i].Name < o[j].Name
+}
+
+func (o *objectList) Swap(i int, j int) {
+	d := *o
+	d[i], d[j] = d[j], d[i]
+}

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -7,6 +7,7 @@ type Object struct {
 	Content    []byte
 }
 
+// ID is useful for comparing objects
 func (o *Object) ID() string {
 	return o.BucketName + "/" + o.Name
 }

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -2,9 +2,10 @@ package backend
 
 // Object represents the object that is stored within the fake server.
 type Object struct {
-	BucketName string
-	Name       string
+	BucketName string `json:"-"`
+	Name       string `json:"-"`
 	Content    []byte
+	Crc32c     string
 }
 
 // ID is useful for comparing objects

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -1,0 +1,12 @@
+package backend
+
+// Storage is the generic interface for implementing the backend storage of the server
+type Storage interface {
+	CreateBucket(name string) error
+	ListBuckets() ([]string, error)
+	GetBucket(name string) error
+	CreateObject(obj Object) error
+	ListObjects(bucketName, prefix, delimiter string) ([]Object, []string, error)
+	GetObject(bucketName, objectName string) (Object, error)
+	DeleteObject(bucketName, objectName string) error
+}

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -6,7 +6,7 @@ type Storage interface {
 	ListBuckets() ([]string, error)
 	GetBucket(name string) error
 	CreateObject(obj Object) error
-	ListObjects(bucketName, prefix, delimiter string) ([]Object, []string, error)
+	ListObjects(bucketName string) ([]Object, error)
 	GetObject(bucketName, objectName string) (Object, error)
 	DeleteObject(bucketName, objectName string) error
 }


### PR DESCRIPTION
This PR adds the ability to persist stored files to disk. This is helpful when using this server in development (as opposed to just in tests). Usage looks like:

```go
fakestorage.NewServerWithOptions(fakestorage.Options{
		InitialObjects: []fakestorage.Object{
			{
				BucketName: "bucket",
				Name:       "object",
				Content:    []byte("An example object."),
			},
		},
		Host:        "0.0.0.0",
		Port:        4443,
		StorageRoot: "/storage",
	})
```

This PR is broken up into 3 parts for easy reviewing:
- Separate the storage details from the server implementation, including basic smoke tests for the storage backend
- Implement an alternative filesystem implementation of the storage backend for persistence
- Clean ups and better error handling.

I took special care to make sure I don't break the existing package API, but because some methods didn't have an error return argument, I had to add some panics. I think that's a reasonable tradeoff for now and the errors can be returned when you decide it's okay to break backwards compatibility.