### PR TITLE
Make compatible with latest cloud go library

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.19.0"
+  version = "0.19.0 - 0.23.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"


### PR DESCRIPTION
Projects using newer versions of `cloud.google.com/go` cannot use this library due to it being version locked to `0.19.0`.

There are no changes since version `0.19.0` that would affect the behavior of this library (see https://github.com/GoogleCloudPlatform/google-cloud-go/blob/master/README.md for changelog).

Pull request includes the changes necessary for it to be compatible with every version from `0.19.0` to the latest version, `0.23.0`.