### PR TITLE
Update cloud.google.com/go dependency

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.19.0 - 0.23.0"
+  version = "0.19.0 - 0.25.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"


### PR DESCRIPTION
I've tested it and it's working with 0.25.0 and that's what I'm using. This allows me to remove the override in my Gopkg.toml.