### PR TITLE
Update Gopkg.toml to be able to use 0.28.0 version Google SDK

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.19.0 - 0.26.0"
+  version = "0.19.0 - 0.28.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"


### PR DESCRIPTION
I've tested this version of SDK and it works absolutely perfect, so we can safely extend the version constraint.