### PR TITLE
fakestorage: add support for MD5 checksum of object content

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -22,7 +22,8 @@ type Object struct {
 	Name       string `json:"name"`
 	Content    []byte `json:"-"`
 	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
-	Crc32c string `json:"crc32c,omitempty"`
+	Crc32c  string `json:"crc32c,omitempty"`
+	Md5Hash string `json:"md5hash,omitempty"`
 }
 
 func (o *Object) id() string {
@@ -102,6 +103,7 @@ func toBackendObjects(objects []Object) []backend.Object {
 			Name:       o.Name,
 			Content:    o.Content,
 			Crc32c:     o.Crc32c,
+			Md5Hash:    o.Md5Hash,
 		})
 	}
 	return backendObjects
@@ -115,6 +117,7 @@ func fromBackendObjects(objects []backend.Object) []Object {
 			Name:       o.Name,
 			Content:    o.Content,
 			Crc32c:     o.Crc32c,
+			Md5Hash:    o.Md5Hash,
 		})
 	}
 	return backendObjects
@@ -187,6 +190,7 @@ func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 		Name:       vars["destinationObject"],
 		Content:    append([]byte(nil), obj.Content...),
 		Crc32c:     obj.Crc32c,
+		Md5Hash:    obj.Md5Hash,
 	}
 	s.CreateObject(newObject)
 	w.Header().Set("Content-Type", "application/json")

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -59,17 +59,19 @@ type objectResponse struct {
 	Bucket string `json:"bucket"`
 	Size   int64  `json:"size,string"`
 	// Crc32c: CRC32c checksum, same as in google storage client code
-	Crc32c string `json:"crc32c,omitempty"`
+	Crc32c  string `json:"crc32c,omitempty"`
+	Md5Hash string `json:"md5hash,omitempty"`
 }
 
 func newObjectResponse(obj Object) objectResponse {
 	return objectResponse{
-		Kind:   "storage#object",
-		ID:     obj.id(),
-		Bucket: obj.BucketName,
-		Name:   obj.Name,
-		Size:   int64(len(obj.Content)),
-		Crc32c: obj.Crc32c,
+		Kind:    "storage#object",
+		ID:      obj.id(),
+		Bucket:  obj.BucketName,
+		Name:    obj.Name,
+		Size:    int64(len(obj.Content)),
+		Crc32c:  obj.Crc32c,
+		Md5Hash: obj.Md5Hash,
 	}
 }
 

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -60,6 +60,7 @@ func TestObjectCRUD(t *testing.T) {
 	const objectName = "video/hi-res/best_video_1080p.mp4"
 	content1 := []byte("content1")
 	const crc1 = "crc1"
+	const md51 = "md51"
 	content2 := []byte("content2")
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		// Get in non-existent case
@@ -69,7 +70,7 @@ func TestObjectCRUD(t *testing.T) {
 		err = storage.DeleteObject(bucketName, objectName)
 		shouldError(t, err, "object successfully delete before being created")
 		// Create in non-existent case
-		noError(t, storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1, Crc32c: crc1}))
+		noError(t, storage.CreateObject(Object{BucketName: bucketName, Name: objectName, Content: content1, Crc32c: crc1, Md5Hash: md51}))
 		// Get in existent case
 		obj, err := storage.GetObject(bucketName, objectName)
 		noError(t, err)
@@ -81,6 +82,9 @@ func TestObjectCRUD(t *testing.T) {
 		}
 		if obj.Crc32c != crc1 {
 			t.Errorf("wrong crc\n want %q\ngot  %q", crc1, obj.Crc32c)
+		}
+		if obj.Md5Hash != md51 {
+			t.Errorf("wrong md5\n want %q\ngot  %q", md51, obj.Md5Hash)
 		}
 		if !bytes.Equal(obj.Content, content1) {
 			t.Errorf("wrong object content\n want %q\ngot  %q", content1, obj.Content)

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -10,6 +10,7 @@ type Object struct {
 	Name       string `json:"-"`
 	Content    []byte
 	Crc32c     string
+	Md5Hash    string
 }
 
 // ID is useful for comparing objects


### PR DESCRIPTION
We'd like to use this library to test some GCS related code that relies on the MD5 object attributes. From my testing, I believe this to be correct and I greatly cribbed off the crc32c implementation. Happy to implement any improvements suggested though.

Thanks for the library!