### PR TITLE
Using lowercase keys in bucketResponse struct json

### DIFF
--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -28,8 +28,8 @@ func newListBucketsResponse(bucketNames []string) listResponse {
 
 type bucketResponse struct {
 	Kind string `json:"kind"`
-	ID   string `json:"ID"`
-	Name string `json:"Name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 func newBucketResponse(bucketName string) bucketResponse {


### PR DESCRIPTION
Google Cloud Storage REST APIs use lowercase keys in json bucket response.
This will get the fake server to work with the GCS library.
Without this `client.list_buckets()` is returning:
```
[<Bucket: None>, <Bucket: None>]
```
with this patch:
```
[<Bucket: another-bucket>, <Bucket: bucket>]
```