### PR TITLE
Adding download route to the mux server

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -136,6 +136,7 @@ func (s *Server) buildMuxer() {
 	r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.getObject)
 	r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
 	r.Path("/b/{sourceBucket}/o/{sourceObject:.+}/rewriteTo/b/{destinationBucket}/o/{destinationObject:.+}").HandlerFunc(s.rewriteObject)
+	s.mux.Path("/download/storage/v1/b/{bucketName}/o/{objectName}").Methods("GET").HandlerFunc(s.downloadObject)
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
 }


### PR DESCRIPTION
Hi @fsouza,
here is a small change to get the fake server to run together with the python client library.

I have a somehow working version of the library packaged in a container here: https://github.com/teone/gc-fake-storage