### PR TITLE
Add optional custom public host

### DIFF
--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -98,6 +98,95 @@ func testDownloadObject(t *testing.T, server *Server) {
 			"",
 		},
 	}
+	expected := "https://storage.googleapis.com"
+	if server.PublicURL() != expected {
+		t.Fatalf("Expected PublicURL \"%s\", is \"%s\".", expected, server.PublicURL())
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			client := server.HTTPClient()
+			req, err := http.NewRequest(test.method, test.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+			}
+			for k, expectedV := range test.expectedHeaders {
+				if v := resp.Header.Get(k); v != expectedV {
+					t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
+				}
+			}
+			data, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if body := string(data); body != test.expectedBody {
+				t.Errorf("wrong body\nwant %q\ngot  %q", test.expectedBody, body)
+			}
+		})
+	}
+}
+
+func TestDownloadObjectAlternatePublicHost(t *testing.T) {
+	var tests = []struct {
+		name            string
+		method          string
+		url             string
+		expectedHeaders map[string]string
+		expectedBody    string
+	}{
+		{
+			"GET: bucket in the path",
+			http.MethodGet,
+			"https://storage.gcs.127.0.0.1.nip.io:4443/some-bucket/files/txt/text-01.txt",
+			map[string]string{"accept-ranges": "bytes", "content-length": "9"},
+			"something",
+		},
+		{
+			"GET: bucket in the host",
+			http.MethodGet,
+			"https://other-bucket.storage.gcs.127.0.0.1.nip.io:4443/static/css/website.css",
+			map[string]string{"accept-ranges": "bytes", "content-length": "21"},
+			"body {display: none;}",
+		},
+		{
+			"HEAD: bucket in the path",
+			http.MethodHead,
+			"https://storage.gcs.127.0.0.1.nip.io:4443/some-bucket/files/txt/text-01.txt",
+			map[string]string{"accept-ranges": "bytes", "content-length": "9"},
+			"",
+		},
+		{
+			"HEAD: bucket in the host",
+			http.MethodHead,
+			"https://other-bucket.storage.gcs.127.0.0.1.nip.io:4443/static/css/website.css",
+			map[string]string{"accept-ranges": "bytes", "content-length": "21"},
+			"",
+		},
+	}
+	objs := []Object{
+		{BucketName: "some-bucket", Name: "files/txt/text-01.txt", Content: []byte("something")},
+		{BucketName: "other-bucket", Name: "static/css/website.css", Content: []byte("body {display: none;}")},
+	}
+	opts := Options{
+		InitialObjects: objs,
+		PublicHost:     "storage.gcs.127.0.0.1.nip.io:4443",
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "https://storage.gcs.127.0.0.1.nip.io:4443"
+	if server.PublicURL() != expected {
+		t.Fatalf("Expected PublicURL \"%s\", is \"%s\".", expected, server.PublicURL())
+	}
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Add the ability to specify a different public host than ``storage.googleapis.com``. This would be used by https://github.com/teone/gc-fake-storage to serve files.  This is set before ``buildMuxer()`` is called, and can be returned by ``PublicURL()``.