### PR TITLE
multipartUpload accepts object name in query param

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -146,9 +146,15 @@ func (s *Server) multipartUpload(bucketName string, w http.ResponseWriter, r *ht
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	objName := r.URL.Query().Get("name")
+	if objName == "" && metadata != nil {
+		objName = metadata.Name
+	}
+
 	obj := Object{
 		BucketName:  bucketName,
-		Name:        metadata.Name,
+		Name:        objName,
 		Content:     content,
 		ContentType: contentType,
 		Crc32c:      encodedCrc32cChecksum(content),

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -148,7 +148,7 @@ func (s *Server) multipartUpload(bucketName string, w http.ResponseWriter, r *ht
 	}
 
 	objName := r.URL.Query().Get("name")
-	if objName == "" && metadata != nil {
+	if objName == "" {
 		objName = metadata.Name
 	}
 


### PR DESCRIPTION
As per documentation: https://cloud.google.com/storage/docs/json_api/v1/objects/insert the name of the object can either come from the query parameters or from the body.

It seems like its up to the implementors on which one to choose as the `go` storage client will send the name inside the body whereas the `nodejs` client sends it in the query params