### PR TITLE
github/workflows/main: compile golangci-lint on the fly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,21 +26,26 @@ jobs:
 
       - uses: actions/checkout@v1.0.0
 
-      - name: go-mod-download
-        run: go mod download
+      - name: install deps
+        run: |
+          go mod download
+          (
+            cd /tmp
+            env GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          )
         env:
           GOPROXY: https://proxy.golang.org
 
       - name: run-linter
-        uses: docker://golangci/golangci-lint
+        run: golangci-lint run
         env:
-          GOROOT: /usr/local/go
-        with:
-          entrypoint: golangci-lint
-          args: run
+          GOPROXY: off
+          GOFLAGS: -mod=readonly
 
       - name: run-tests
         run: go test -race -vet all -mod readonly ./...
+        env:
+          GOPROXY: off
 
   build:
     name: build-and-publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
           GOPROXY: https://proxy.golang.org
 
       - name: run-linter
-        run: golangci-lint run
+        run: |
+          $(go env GOPATH)/bin/golangci-lint run
         env:
           GOPROXY: off
           GOFLAGS: -mod=readonly


### PR DESCRIPTION
golangci-lint can be quickly installed using go modules, and that should
be faster. Without this change, our deps are getting downloaded twice.
While golangci-lint does have more dependencies than fake-gcs-server,
I'm banking on the fact that we won't need to download golangci-lint's
Docker image and this should speed things up :D