### PR TITLE
GetObject can download content

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -154,6 +154,12 @@ func (s *Server) listObjects(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+
+	if alt := r.URL.Query().Get("alt"); alt == "media" {
+		s.downloadObject(w, r)
+		return
+	}
+
 	encoder := json.NewEncoder(w)
 	obj, err := s.GetObject(vars["bucketName"], vars["objectName"])
 	if err != nil {

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -84,6 +84,13 @@ func testDownloadObject(t *testing.T, server *Server) {
 			"body {display: none;}",
 		},
 		{
+			"GET: using storage api",
+			http.MethodGet,
+			"https://storage.googleapis.com/storage/v1/b/some-bucket/o/files/txt/text-01.txt?alt=media",
+			map[string]string{"accept-ranges": "bytes", "content-length": "9"},
+			"something",
+		},
+		{
 			"HEAD: bucket in the path",
 			http.MethodHead,
 			"https://storage.googleapis.com/some-bucket/files/txt/text-01.txt",


### PR DESCRIPTION
Getting an object through the storage api can download the content of file when query param `alt=media`. Docs: https://cloud.google.com/storage/docs/json_api/v1/objects/get