### PR TITLE
internal/backend: keep raw []storage.ACL in backend.Object

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,12 +78,6 @@ jobs:
           entrypoint: sh
           args: ci/run-python-example.sh
 
-      - name: test-node-example
-        uses: docker://node:10-alpine
-        with:
-          entrypoint: sh
-          args: ci/run-node-example.sh
-
       - name: test-go-example
         uses: docker://golang:1.13-alpine
         env:

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -98,7 +98,6 @@ func (s *Server) ListObjects(bucketName, prefix, delimiter string) ([]Object, []
 func toBackendObjects(objects []Object) []backend.Object {
 	backendObjects := []backend.Object{}
 	for _, o := range objects {
-		acl, _ := json.Marshal(o.ACL)
 		backendObjects = append(backendObjects, backend.Object{
 			BucketName:      o.BucketName,
 			Name:            o.Name,
@@ -107,7 +106,7 @@ func toBackendObjects(objects []Object) []backend.Object {
 			ContentEncoding: o.ContentEncoding,
 			Crc32c:          o.Crc32c,
 			Md5Hash:         o.Md5Hash,
-			ACL:             acl,
+			ACL:             o.ACL,
 		})
 	}
 	return backendObjects
@@ -116,8 +115,6 @@ func toBackendObjects(objects []Object) []backend.Object {
 func fromBackendObjects(objects []backend.Object) []Object {
 	backendObjects := []Object{}
 	for _, o := range objects {
-		var acl []storage.ACLRule
-		_ = json.Unmarshal(o.ACL, &acl)
 		backendObjects = append(backendObjects, Object{
 			BucketName:      o.BucketName,
 			Name:            o.Name,
@@ -126,7 +123,7 @@ func fromBackendObjects(objects []backend.Object) []Object {
 			ContentEncoding: o.ContentEncoding,
 			Crc32c:          o.Crc32c,
 			Md5Hash:         o.Md5Hash,
-			ACL:             acl,
+			ACL:             o.ACL,
 		})
 	}
 	return backendObjects

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -4,6 +4,8 @@
 
 package backend
 
+import "cloud.google.com/go/storage"
+
 // Object represents the object that is stored within the fake server.
 type Object struct {
 	BucketName      string `json:"-"`
@@ -13,7 +15,7 @@ type Object struct {
 	Content         []byte
 	Crc32c          string
 	Md5Hash         string
-	ACL             []byte
+	ACL             []storage.ACLRule
 }
 
 // ID is useful for comparing objects


### PR DESCRIPTION
Should improve error handling overall.