### PR TITLE
Support to queries against all versions (in versioned and not versioned a buckets)

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -74,8 +74,8 @@ func (s *Server) createObject(obj Object) error {
 
 // ListObjects returns a sorted list of objects that match the given criteria,
 // or an error if the bucket doesn't exist.
-func (s *Server) ListObjects(bucketName, prefix, delimiter string) ([]Object, []string, error) {
-	backendObjects, err := s.backend.ListObjects(bucketName)
+func (s *Server) ListObjects(bucketName, prefix, delimiter string, versions bool) ([]Object, []string, error) {
+	backendObjects, err := s.backend.ListObjects(bucketName, versions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,7 +186,9 @@ func (s *Server) listObjects(w http.ResponseWriter, r *http.Request) {
 	bucketName := mux.Vars(r)["bucketName"]
 	prefix := r.URL.Query().Get("prefix")
 	delimiter := r.URL.Query().Get("delimiter")
-	objs, prefixes, err := s.ListObjects(bucketName, prefix, delimiter)
+	versions := r.URL.Query().Get("versions")
+
+	objs, prefixes, err := s.ListObjects(bucketName, prefix, delimiter, versions == "true")
 	encoder := json.NewEncoder(w)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -676,7 +676,8 @@ func contains(s []int64, e int64) bool {
 	return false
 }
 
-func unique(in []string) (out []string) {
+func unique(in []string) []string {
+	out := []string{}
 	found := make(map[string]bool)
 	for _, entry := range in {
 		if _, value := found[entry]; !value {
@@ -819,10 +820,8 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 					t.Errorf("wrong names returned\nwant %#v\ngot  %#v", test.expectedNames, names)
 				}
 			})
-
 		})
 	}
-
 }
 
 func TestServiceClientListObjectsBucketNotFound(t *testing.T) {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -786,9 +786,12 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		runServersTest(t, nil, func(t *testing.T, server *Server) {
-			server.CreateBucket("some-bucket", test.versioningEnabled)
-			server.CreateBucket("other-bucket", test.versioningEnabled)
-			server.CreateBucket("empty-bucket", test.versioningEnabled)
+			for _, bucketName := range []string{"some-bucket", "other-bucket", "empty-bucket"} {
+				server.CreateBucketWithOpts(CreateBucketOpts{
+					Name:              bucketName,
+					VersioningEnabled: test.versioningEnabled,
+				})
+			}
 			for _, obj := range getObjectsForListTests() {
 				obj.Generation = initialGeneration
 				server.CreateObject(obj)

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -676,6 +676,17 @@ func contains(s []int64, e int64) bool {
 	return false
 }
 
+func unique(in []string) (out []string) {
+	found := make(map[string]bool)
+	for _, entry := range in {
+		if _, value := found[entry]; !value {
+			found[entry] = true
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
 func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 	const initialGeneration = 1234
 	const finalGeneration = initialGeneration + 1
@@ -804,7 +815,7 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 					t.Errorf("wrong number objects\nwant %d\ngot  %d", test.expectedNumObjects, len(names))
 				}
 
-				if !reflect.DeepEqual(names, test.expectedNames) {
+				if !reflect.DeepEqual(unique(names), test.expectedNames) {
 					t.Errorf("wrong names returned\nwant %#v\ngot  %#v", test.expectedNames, names)
 				}
 			})

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -762,7 +762,7 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 		{
 			listTest{"no prefix, no delimiter, no objects, versioning and overwrites",
 				"empty-bucket",
-				nil,
+				&storage.Query{Versions: true},
 				[]string{},
 				nil},
 			[]int64{},

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -132,13 +132,24 @@ func TestObjectCRUD(t *testing.T) {
 				}
 			}
 
-			objs, err := storage.ListObjects(bucketName)
+			t.Logf("checking active object is the expected one when versioning is %t", versioningEnabled)
+			objs, err := storage.ListObjects(bucketName, false)
 			noError(t, err)
 			if len(objs) != 1 {
 				t.Errorf("wrong number of objects returned\nwant 1\ngot  %d", len(objs))
 			}
 			if objs[0].Name != objectName {
 				t.Errorf("wrong object name\nwant %q\ngot  %q", objectName, objs[0].Name)
+			}
+
+			t.Logf("checking all object listing is the expected one when versioning is %t", versioningEnabled)
+			objs, err = storage.ListObjects(bucketName, true)
+			noError(t, err, "list all objects")
+			if versioningEnabled && len(objs) != 2 {
+				t.Errorf("wrong number of objects returned\nwant 2\ngot  %d", len(objs))
+			}
+			if !versioningEnabled && len(objs) != 1 {
+				t.Errorf("wrong number of objects returned\nwant 1\ngot  %d", len(objs))
 			}
 
 			err = storage.DeleteObject(bucketName, objectName)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -144,7 +144,7 @@ func TestObjectCRUD(t *testing.T) {
 
 			t.Logf("checking all object listing is the expected one when versioning is %t", versioningEnabled)
 			objs, err = storage.ListObjects(bucketName, true)
-			noError(t, err, "list all objects")
+			noError(t, err)
 			if versioningEnabled && len(objs) != 2 {
 				t.Errorf("wrong number of objects returned\nwant 2\ngot  %d", len(objs))
 			}

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -109,9 +109,10 @@ func (s *StorageFS) CreateObject(obj Object) error {
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and delimeter
-func (s *StorageFS) ListObjects(bucketName string) ([]Object, error) {
+func (s *StorageFS) ListObjects(bucketName string, versions bool) ([]Object, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
+
 	infos, err := ioutil.ReadDir(path.Join(s.rootDir, url.PathEscape(bucketName)))
 	if err != nil {
 		return nil, err

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -167,14 +167,17 @@ func (s *StorageMemory) CreateObject(obj Object) error {
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and delimeter
-func (s *StorageMemory) ListObjects(bucketName string) ([]Object, error) {
+func (s *StorageMemory) ListObjects(bucketName string, versions bool) ([]Object, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	bucketInMemory, err := s.getBucketInMemory(bucketName)
 	if err != nil {
 		return []Object{}, err
 	}
-	return bucketInMemory.activeObjects, nil
+	if !versions {
+		return bucketInMemory.activeObjects, nil
+	}
+	return append(bucketInMemory.activeObjects, bucketInMemory.archivedObjects...), nil
 }
 
 // GetObject get an object by bucket and name

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -11,7 +11,7 @@ type Storage interface {
 	ListBuckets() ([]Bucket, error)
 	GetBucket(name string) (Bucket, error)
 	CreateObject(obj Object) error
-	ListObjects(bucketName string) ([]Object, error)
+	ListObjects(bucketName string, versions bool) ([]Object, error)
 	GetObject(bucketName, objectName string) (Object, error)
 	GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error)
 	DeleteObject(bucketName, objectName string) error


### PR DESCRIPTION
_note: incremental PR: the review and potential merge should go after https://github.com/fsouza/fake-gcs-server/pull/60_ 

Support for querying all versions, that means multiple generations of each file are expected in versioned buckets where there has been overwrites or deletions

Done:
* some queries with "versioning equal to true" at fakestorage level, testing a couple of scenarios
* Incorporating two simple calls to list query (one with versioning equal to false, as we had, and another with true) in the backend tests (`TestObjectCRUD`)
* implementation (easiest part actually)
