### PR TITLE
Rewrite with generation support

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -298,7 +298,23 @@ func (s *Server) setObjectACL(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	obj, err := s.GetObject(vars["sourceBucket"], vars["sourceObject"])
+	generationStr := r.FormValue("sourceGeneration")
+	var (
+		obj        Object
+		err        error
+		generation int64
+	)
+	if generationStr != "" {
+		generation, err = strconv.ParseInt(generationStr, 10, 64)
+		if err != nil {
+			fmt.Println(err)
+			http.Error(w, "Wrong generation ID", http.StatusBadRequest)
+			return
+		}
+		obj, err = s.GetObjectWithGeneration(vars["sourceBucket"], vars["sourceObject"], generation)
+	} else {
+		obj, err = s.GetObject(vars["sourceBucket"], vars["sourceObject"])
+	}
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -307,7 +307,6 @@ func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 	if generationStr != "" {
 		generation, err = strconv.ParseInt(generationStr, 10, 64)
 		if err != nil {
-			fmt.Println(err)
 			http.Error(w, "Wrong generation ID", http.StatusBadRequest)
 			return
 		}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1004,8 +1004,8 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 		test := test
 		t.Run(test.testCase, func(t *testing.T) {
 			runServersTest(t, []Object{}, func(t *testing.T, server *Server) {
-				server.CreateBucket("empty-bucket", false)
-				server.CreateBucket("first-bucket", test.versioning)
+				server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket", VersioningEnabled: false})
+				server.CreateBucketWithOpts(CreateBucketOpts{Name: "first-bucket", VersioningEnabled: test.versioning})
 				for _, obj := range objs {
 					server.CreateObject(obj)
 				}


### PR DESCRIPTION
_note: again incremental PR: the review and potential merge should go after https://github.com/fsouza/fake-gcs-server/pull/140_ 

An easy one: just looking and considering the optional query arg that may come with rewrite (copy) requests to specify an specific generation of an object. Tests decoupled from the ones that work without versioning neither specific generations, so we initialize the buckets accordingly. Extra test scenario considered for rewrite object (against the same active object)