### PR TITLE
Support for bucket creation time

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -70,7 +70,12 @@ func (s *Server) createBucketByPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return the created bucket:
-	resp := newBucketResponse(name, versioning)
+	bucket, err := s.backend.GetBucket(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := newBucketResponse(bucket)
 	json.NewEncoder(w).Encode(resp)
 }
 
@@ -94,7 +99,7 @@ func (s *Server) getBucket(w http.ResponseWriter, r *http.Request) {
 		encoder.Encode(err)
 		return
 	}
-	resp := newBucketResponse(bucket.Name, bucket.VersioningEnabled)
+	resp := newBucketResponse(bucket)
 	w.WriteHeader(http.StatusOK)
 	encoder.Encode(resp)
 }

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -21,7 +22,7 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		{BucketName: "some-bucket", Name: "img/hi-res/party-03.jpg"},
 		{BucketName: "other-bucket", Name: "static/css/website.css"},
 	}
-
+	startTime := time.Now()
 	runServersTest(t, objs, func(t *testing.T, server *Server) {
 		client := server.Client()
 		attrs, err := client.Bucket("some-bucket").Attrs(context.Background())
@@ -34,6 +35,9 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		}
 		if attrs.VersioningEnabled != false {
 			t.Errorf("wrong bucket props for %q\nexpecting no versioning by default, got it enabled", expectedName)
+		}
+		if attrs.Created.Before(startTime.Truncate(time.Second)) || time.Now().Before(attrs.Created) {
+			t.Errorf("expecting bucket creation date between test start time %v and now %v, got %v", startTime, time.Now(), attrs.Created)
 		}
 	})
 }

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -298,7 +298,23 @@ func (s *Server) setObjectACL(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	obj, err := s.GetObject(vars["sourceBucket"], vars["sourceObject"])
+	generationStr := r.FormValue("sourceGeneration")
+	var (
+		obj        Object
+		err        error
+		generation int64
+	)
+	if generationStr != "" {
+		generation, err = strconv.ParseInt(generationStr, 10, 64)
+		if err != nil {
+			fmt.Println(err)
+			http.Error(w, "Wrong generation ID", http.StatusBadRequest)
+			return
+		}
+		obj, err = s.GetObjectWithGeneration(vars["sourceBucket"], vars["sourceObject"], generation)
+	} else {
+		obj, err = s.GetObject(vars["sourceBucket"], vars["sourceObject"])
+	}
 	if err != nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -307,7 +307,6 @@ func (s *Server) rewriteObject(w http.ResponseWriter, r *http.Request) {
 	if generationStr != "" {
 		generation, err = strconv.ParseInt(generationStr, 10, 64)
 		if err != nil {
-			fmt.Println(err)
 			http.Error(w, "Wrong generation ID", http.StatusBadRequest)
 			return
 		}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1004,8 +1004,8 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 		test := test
 		t.Run(test.testCase, func(t *testing.T) {
 			runServersTest(t, []Object{}, func(t *testing.T, server *Server) {
-				server.CreateBucket("empty-bucket", false)
-				server.CreateBucket("first-bucket", test.versioning)
+				server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket", VersioningEnabled: false})
+				server.CreateBucketWithOpts(CreateBucketOpts{Name: "first-bucket", VersioningEnabled: test.versioning})
 				for _, obj := range objs {
 					server.CreateObject(obj)
 				}

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -25,28 +25,30 @@ func newListBucketsResponse(buckets []backend.Bucket) listResponse {
 		Items: make([]interface{}, len(buckets)),
 	}
 	for i, bucket := range buckets {
-		resp.Items[i] = newBucketResponse(bucket.Name, bucket.VersioningEnabled)
+		resp.Items[i] = newBucketResponse(bucket)
 	}
 	return resp
 }
 
 type bucketResponse struct {
-	Kind       string            `json:"kind"`
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	Versioning *bucketVersioning `json:"versioning,omitempty"`
+	Kind        string            `json:"kind"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Versioning  *bucketVersioning `json:"versioning,omitempty"`
+	TimeCreated string            `json:"timeCreated,omitempty"`
 }
 
 type bucketVersioning struct {
 	Enabled bool `json:"enabled,omitempty"`
 }
 
-func newBucketResponse(bucketName string, versioningEnabled bool) bucketResponse {
+func newBucketResponse(bucket backend.Bucket) bucketResponse {
 	return bucketResponse{
-		Kind:       "storage#bucket",
-		ID:         bucketName,
-		Name:       bucketName,
-		Versioning: &bucketVersioning{versioningEnabled},
+		Kind:        "storage#bucket",
+		ID:          bucket.Name,
+		Name:        bucket.Name,
+		Versioning:  &bucketVersioning{bucket.VersioningEnabled},
+		TimeCreated: bucket.TimeCreated.Format(time.RFC3339),
 	}
 }
 

--- a/internal/backend/bucket.go
+++ b/internal/backend/bucket.go
@@ -1,7 +1,10 @@
 package backend
 
+import "time"
+
 // Bucket represents the bucket that is stored within the fake server.
 type Bucket struct {
 	Name              string
 	VersioningEnabled bool
+	TimeCreated       time.Time
 }

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -24,7 +24,7 @@ type bucketInMemory struct {
 }
 
 func newBucketInMemory(name string, versioningEnabled bool) bucketInMemory {
-	return bucketInMemory{Bucket{name, versioningEnabled}, []Object{}, []Object{}}
+	return bucketInMemory{Bucket{name, versioningEnabled, time.Now()}, []Object{}, []Object{}}
 }
 
 func (bm *bucketInMemory) addObject(obj Object) {
@@ -132,8 +132,8 @@ func (s *StorageMemory) ListBuckets() ([]Bucket, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	buckets := []Bucket{}
-	for bucket := range s.buckets {
-		buckets = append(buckets, Bucket{s.buckets[bucket].Name, s.buckets[bucket].VersioningEnabled})
+	for _, bucketInMemory := range s.buckets {
+		buckets = append(buckets, Bucket{bucketInMemory.Name, bucketInMemory.VersioningEnabled, bucketInMemory.TimeCreated})
 	}
 	return buckets, nil
 }
@@ -143,7 +143,7 @@ func (s *StorageMemory) GetBucket(name string) (Bucket, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	bucketInMemory, err := s.getBucketInMemory(name)
-	return Bucket{bucketInMemory.Name, bucketInMemory.VersioningEnabled}, err
+	return Bucket{bucketInMemory.Name, bucketInMemory.VersioningEnabled, bucketInMemory.TimeCreated}, err
 }
 
 func (s *StorageMemory) getBucketInMemory(name string) (bucketInMemory, error) {


### PR DESCRIPTION
_Again, incremental PR: to be considered after: https://github.com/fsouza/fake-gcs-server/pull/143_

This time not connected to versioning: extending the bucket representation in the memory engine to store the original bucket creation date, while in FS we are using the bucket root dir ctime to fill that field (and that is wrong, but persisting bucket metadata in that engine in a magic file looks overkilling in the current state), and extending then responses.
