### PR TITLE
Fix capitalisation in md5Hash metadata

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -27,7 +27,7 @@ type Object struct {
 	Content         []byte `json:"-"`
 	// Crc32c checksum of Content. calculated by server when it's upload methods are used.
 	Crc32c  string            `json:"crc32c,omitempty"`
-	Md5Hash string            `json:"md5hash,omitempty"`
+	Md5Hash string            `json:"md5Hash,omitempty"`
 	ACL     []storage.ACLRule `json:"acl,omitempty"`
 	// Dates and generation can be manually injected, so you can do assertions on them,
 	// or let us fill these fields for you

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -865,7 +865,7 @@ func TestServiceClientRewriteObject(t *testing.T) {
 			bucketName string
 			objectName string
 			crc32c     uint32
-			md5hash    string
+			md5Hash    string
 		}{
 			{
 				"same bucket same file",

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -74,7 +74,7 @@ type objectResponse struct {
 	ContentEncoding string                         `json:"contentEncoding,omitempty"`
 	Crc32c          string                         `json:"crc32c,omitempty"`
 	ACL             []*storage.ObjectAccessControl `json:"acl,omitempty"`
-	Md5Hash         string                         `json:"md5hash,omitempty"`
+	Md5Hash         string                         `json:"md5Hash,omitempty"`
 	TimeCreated     string                         `json:"timeCreated,omitempty"`
 	TimeDeleted     string                         `json:"timeDeleted,omitempty"`
 	Updated         string                         `json:"updated,omitempty"`


### PR DESCRIPTION
The `md5Hash` member of metadata objects is currently being returned incorrectly as `md5hash`.

This breaks things like md5 hash validation in the nodejs client. For example, this line in Google's client checks for the `md5Hash` member:
https://github.com/googleapis/nodejs-storage/blob/63deb51d1727519ff926c1aabc6b0b5fb6f87d12/src/file.ts#L1385

See also the documentation at https://cloud.google.com/storage/docs/json_api/v1/objects

This patch renames the variable when serialising.