### PR TITLE
Implement minimal support for PATCH metadata API

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -175,6 +175,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b/{bucketName}").Methods("GET").HandlerFunc(s.getBucket)
 		r.Path("/b/{bucketName}/o").Methods("GET").HandlerFunc(s.listObjects)
 		r.Path("/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
+		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("PATCH").HandlerFunc(s.patchObject)
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods("GET").HandlerFunc(s.listObjectACL)
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl/{entity}").Methods("PUT").HandlerFunc(s.setObjectACL)
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.getObject)

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -185,9 +185,12 @@ func (s *StorageFS) PatchObject(bucketName, objectName string, metadata map[stri
 	if err != nil {
 		return Object{}, err
 	}
+	if obj.Metadata == nil {
+		obj.Metadata = map[string]string{}
+	}
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
-	s.CreateObject(obj)
+	s.CreateObject(obj) // recreate object
 	return obj, nil
 }

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -179,3 +179,15 @@ func (s *StorageFS) DeleteObject(bucketName, objectName string) error {
 	}
 	return os.Remove(filepath.Join(s.rootDir, url.PathEscape(bucketName), url.PathEscape(objectName)))
 }
+
+func (s *StorageFS) PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+	obj, err := s.GetObject(bucketName, objectName)
+	if err != nil {
+		return Object{}, err
+	}
+	for k, v := range metadata {
+		obj.Metadata[k] = v
+	}
+	s.CreateObject(obj)
+	return obj, nil
+}

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -224,3 +224,14 @@ func (s *StorageMemory) DeleteObject(bucketName, objectName string) error {
 	s.buckets[bucketName] = bucketInMemory
 	return nil
 }
+
+func (s *StorageMemory) PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+	obj, err := s.GetObject(bucketName, objectName)
+	if err != nil {
+		return Object{}, err
+	}
+	for k, v := range metadata {
+		obj.Metadata[k] = v
+	}
+	return obj, nil
+}

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -230,8 +230,12 @@ func (s *StorageMemory) PatchObject(bucketName, objectName string, metadata map[
 	if err != nil {
 		return Object{}, err
 	}
+	if obj.Metadata == nil {
+		obj.Metadata = map[string]string{}
+	}
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
+	s.CreateObject(obj) // recreate object
 	return obj, nil
 }

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -15,4 +15,5 @@ type Storage interface {
 	GetObject(bucketName, objectName string) (Object, error)
 	GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error)
 	DeleteObject(bucketName, objectName string) error
+	PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error)
 }


### PR DESCRIPTION
This PR implements minimal support for `PATCH` object's metadata API.

It patches the object's metadata as per `path parameters` and `metadata` in the request body. It  _completely_ ignores the `optional query parameters` of the API, which are slightly complex. So if this minimal support is acceptable, then we can merge it, and the optional query parameters can be taken care of in later PRs (if needed).

API Ref: https://cloud.google.com/storage/docs/json_api/v1/objects/patch
