### PR TITLE
Support Windows

### DIFF
--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -180,6 +180,9 @@ func TestServerClientObjectAttrsAfterOverwriteWithVersioning(t *testing.T) {
 		t.Logf("checking initial object attributes")
 		checkObjectAttrs(initialObj, originalObjAttrs, t)
 
+		// sleep for at least 100ns or more, so the creation time will differ on all platforms.
+		time.Sleep(time.Microsecond)
+
 		latestObjVersion := Object{BucketName: bucketName, Name: "img/low-res/party-01.jpg", Content: []byte(content2), ContentType: contentType, Crc32c: encodedChecksum(uint32ToBytes(uint32Checksum([]byte(content2)))), Md5Hash: encodedHash(md5Hash([]byte(content2)))}
 		server.CreateObject(latestObjVersion)
 		objHandle = client.Bucket(bucketName).Object(latestObjVersion.Name)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -212,7 +212,7 @@ func TestBucketCreateGetList(t *testing.T) {
 			}
 			timeBeforeCreation := time.Now().Truncate(time.Second) // we may lose precission
 			err = storage.CreateBucket(bucket.Name, bucket.VersioningEnabled)
-			timeAfterCreation := time.Now()
+			timeAfterCreation := time.Now().Add(time.Microsecond)
 			if reflect.TypeOf(storage) == reflect.TypeOf(&storageFS{}) && bucket.VersioningEnabled {
 				if err == nil {
 					t.Fatal("fs storage should not accept creating buckets with versioning, but it's not failing")

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -122,7 +122,7 @@ func (s *storageFS) CreateObject(obj Object) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)), encoded, 0664)
+	return ioutil.WriteFile(filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)), encoded, 0600)
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -173,7 +173,7 @@ func (s *storageFS) getObject(bucketName, objectName string) (Object, error) {
 	if err != nil {
 		return Object{}, err
 	}
-	obj.Name = objectName
+	obj.Name = filepath.ToSlash(objectName)
 	obj.BucketName = bucketName
 	return obj, nil
 }

--- a/internal/backend/time_windows.go
+++ b/internal/backend/time_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2019 Francisco Souza. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package backend
+
+import (
+	"os"
+	"syscall"
+)
+
+func createTimeFromFileInfo(input os.FileInfo) syscall.Timespec {
+	if statT, ok := input.Sys().(*syscall.Win32FileAttributeData); ok {
+		nsec := statT.CreationTime.Nanoseconds()
+		return syscall.NsecToTimespec(nsec)
+	}
+	return syscall.Timespec{}
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -83,7 +82,9 @@ func objectsFromBucket(localBucketPath, bucketName string) ([]fakestorage.Object
 	var objects []fakestorage.Object
 	err := filepath.Walk(localBucketPath, func(path string, info os.FileInfo, _ error) error {
 		if info.Mode().IsRegular() {
-			objectKey := strings.TrimLeft(strings.Replace(path, localBucketPath, "", 1), "/")
+			// Rel() should never return error since path always descend from localBucketPath
+			relPath, _ := filepath.Rel(localBucketPath, path)
+			objectKey := filepath.ToSlash(relPath)
 			fileContent, err := ioutil.ReadFile(path)
 			if err != nil {
 				return fmt.Errorf("could not read file %q: %w", path, err)


### PR DESCRIPTION
* Implemented the function which extracts the creation time on Windows, so the program can be built.
    * Since the file creation time granularity is only down to 100ns, the tests are relaxed a bit.
* Use `filepath.Rel` and `filepath.ToSlash` to calculate the object key from local path, rather than string manipulation, so the backslashes can be properly handled. 