### PR TITLE
fakestorage: misc fixes

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -65,13 +65,11 @@ func (o *objectList) Swap(i int, j int) {
 //
 // If the bucket within the object doesn't exist, it also creates it. If the
 // object already exists, it overrides the object.
-func (s *Server) CreateObject(obj Object) Object {
-	newObj, err := s.createObject(obj)
+func (s *Server) CreateObject(obj Object) {
+	_, err := s.createObject(obj)
 	if err != nil {
 		panic(err)
 	}
-
-	return newObj
 }
 
 func (s *Server) createObject(obj Object) (Object, error) {

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -372,7 +372,7 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 	w.Header().Set(contentTypeHeader, obj.ContentType)
-	w.Header().Set("X-Goog-Generation", fmt.Sprintf("%d", obj.Generation))
+	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))
 	w.WriteHeader(status)
 	if r.Method == http.MethodGet {

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -65,15 +65,22 @@ func (o *objectList) Swap(i int, j int) {
 //
 // If the bucket within the object doesn't exist, it also creates it. If the
 // object already exists, it overrides the object.
-func (s *Server) CreateObject(obj Object) {
-	err := s.createObject(obj)
+func (s *Server) CreateObject(obj Object) Object {
+	newObj, err := s.createObject(obj)
 	if err != nil {
 		panic(err)
 	}
+
+	return newObj
 }
 
-func (s *Server) createObject(obj Object) error {
-	return s.backend.CreateObject(toBackendObjects([]Object{obj})[0])
+func (s *Server) createObject(obj Object) (Object, error) {
+	newObj, err := s.backend.CreateObject(toBackendObjects([]Object{obj})[0])
+	if err != nil {
+		return Object{}, err
+	}
+
+	return fromBackendObjects([]backend.Object{newObj})[0], nil
 }
 
 // ListObjects returns a sorted list of objects that match the given criteria,

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -381,6 +381,9 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(contentTypeHeader, obj.ContentType)
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))
+	if obj.ContentEncoding != "" {
+		w.Header().Set("Content-Encoding", obj.ContentEncoding)
+	}
 	w.WriteHeader(status)
 	if r.Method == http.MethodGet {
 		w.Write(content)

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -190,6 +190,10 @@ func (s *Server) buildMuxer() {
 	s.mux.Path("/download/storage/v1/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.downloadObject)
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
+
+	// Signed URL Uploads
+	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)
+	s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)
 }
 
 // Stop stops the server, closing all connections.

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -85,7 +85,7 @@ func (s *Server) simpleUpload(bucketName string, w http.ResponseWriter, r *http.
 		Md5Hash:         encodedMd5Hash(data),
 		ACL:             getObjectACL(predefinedACL),
 	}
-	err = s.createObject(obj)
+	obj, err = s.createObject(obj)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -192,15 +192,11 @@ func (s *Server) multipartUpload(bucketName string, w http.ResponseWriter, r *ht
 		ACL:             getObjectACL(predefinedACL),
 		Metadata:        metadata.Metadata,
 	}
-	err = s.createObject(obj)
+	obj, err = s.createObject(obj)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	// If the backend created a Generation #, add it to the response
-	newObj, _ := s.GetObject(obj.BucketName, obj.Name)
-	obj.Generation = newObj.Generation
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(obj)
@@ -308,7 +304,7 @@ func (s *Server) uploadFileContent(w http.ResponseWriter, r *http.Request) {
 	}
 	if commit {
 		s.uploads.Delete(uploadID)
-		err = s.createObject(obj)
+		obj, err = s.createObject(obj)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -197,6 +197,11 @@ func (s *Server) multipartUpload(bucketName string, w http.ResponseWriter, r *ht
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// If the backend created a Generation #, add it to the response
+	newObj, _ := s.GetObject(obj.BucketName, obj.Name)
+	obj.Generation = newObj.Generation
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(obj)
 }

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -57,6 +57,17 @@ func (s *Server) insertObject(w http.ResponseWriter, r *http.Request) {
 	case "resumable":
 		s.resumableUpload(bucketName, w, r)
 	default:
+		// Support Signed URL Uploads
+		if r.URL.Query().Get("X-Goog-Algorithm") != "" {
+			switch r.Method {
+			case http.MethodPost:
+				s.resumableUpload(bucketName, w, r)
+			case http.MethodPut:
+				s.signedUpload(bucketName, w, r)
+			}
+
+			return
+		}
 		http.Error(w, "invalid uploadType", http.StatusBadRequest)
 	}
 }
@@ -84,6 +95,50 @@ func (s *Server) simpleUpload(bucketName string, w http.ResponseWriter, r *http.
 		Crc32c:          encodedCrc32cChecksum(data),
 		Md5Hash:         encodedMd5Hash(data),
 		ACL:             getObjectACL(predefinedACL),
+	}
+	obj, err = s.createObject(obj)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(obj)
+}
+
+func (s *Server) signedUpload(bucketName string, w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	name := mux.Vars(r)["objectName"]
+	predefinedACL := r.URL.Query().Get("predefinedAcl")
+	contentEncoding := r.URL.Query().Get("contentEncoding")
+
+	// Load data from HTTP Headers
+	if contentEncoding == "" {
+		contentEncoding = r.Header.Get("Content-Encoding")
+	}
+
+	metaData := make(map[string]string)
+	for key := range r.Header {
+		lowerKey := strings.ToLower(key)
+		if metaDataKey := strings.TrimPrefix(lowerKey, "x-goog-meta-"); metaDataKey != lowerKey {
+			metaData[metaDataKey] = r.Header.Get(key)
+		}
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	obj := Object{
+		BucketName:      bucketName,
+		Name:            name,
+		Content:         data,
+		ContentType:     r.Header.Get(contentTypeHeader),
+		ContentEncoding: contentEncoding,
+		Crc32c:          encodedCrc32cChecksum(data),
+		Md5Hash:         encodedMd5Hash(data),
+		ACL:             getObjectACL(predefinedACL),
+		Metadata:        metaData,
 	}
 	obj, err = s.createObject(obj)
 	if err != nil {

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -61,12 +61,12 @@ func shouldError(t *testing.T, err error) {
 
 func uploadAndCompare(t *testing.T, storage Storage, obj Object) int64 {
 	isFSStorage := reflect.TypeOf(storage) == reflect.TypeOf(&storageFS{})
-	err := storage.CreateObject(obj)
+	_, err := storage.CreateObject(obj)
 	if isFSStorage && obj.Generation != 0 {
 		t.Log("FS should not support objects generation")
 		shouldError(t, err)
 		obj.Generation = 0
-		err = storage.CreateObject(obj)
+		_, err = storage.CreateObject(obj)
 	}
 	noError(t, err)
 	activeObj, err := storage.GetObject(obj.BucketName, obj.Name)
@@ -185,7 +185,7 @@ func TestObjectQueryErrors(t *testing.T) {
 				return
 			}
 			validObject := Object{BucketName: bucketName, Name: "random-object", Content: []byte("random-content")}
-			err = storage.CreateObject(validObject)
+			_, err = storage.CreateObject(validObject)
 			noError(t, err)
 			_, err = storage.GetObjectWithGeneration(validObject.BucketName, validObject.Name, 33333)
 			shouldError(t, err)

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -46,7 +46,7 @@ func NewStorageFS(objects []Object, rootDir string) (Storage, error) {
 	}
 	s := &storageFS{rootDir: rootDir}
 	for _, o := range objects {
-		err := s.CreateObject(o)
+		_, err := s.CreateObject(o)
 		if err != nil {
 			return nil, err
 		}
@@ -108,21 +108,21 @@ func (s *storageFS) GetBucket(name string) (Bucket, error) {
 }
 
 // CreateObject stores an object as a regular file in the disk.
-func (s *storageFS) CreateObject(obj Object) error {
+func (s *storageFS) CreateObject(obj Object) (Object, error) {
 	if obj.Generation > 0 {
-		return errors.New("not implemented: fs storage type does not support objects generation yet")
+		return Object{}, errors.New("not implemented: fs storage type does not support objects generation yet")
 	}
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	err := s.createBucket(obj.BucketName)
 	if err != nil {
-		return err
+		return Object{}, err
 	}
 	encoded, err := json.Marshal(obj)
 	if err != nil {
-		return err
+		return Object{}, err
 	}
-	return ioutil.WriteFile(filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)), encoded, 0600)
+	return obj, ioutil.WriteFile(filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)), encoded, 0600)
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -11,7 +11,7 @@ type Storage interface {
 	CreateBucket(name string, versioningEnabled bool) error
 	ListBuckets() ([]Bucket, error)
 	GetBucket(name string) (Bucket, error)
-	CreateObject(obj Object) error
+	CreateObject(obj Object) (Object, error)
 	ListObjects(bucketName string, versions bool) ([]Object, error)
 	GetObject(bucketName, objectName string) (Object, error)
 	GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error)


### PR DESCRIPTION
* Add Last-Modified and X-Goog-Generation HTTP headers for GET/HEAD object requests
* Fallback to original object's metadata on rewrite requests
* Return object generation number if available after upload
* Fix Object Generation JSON encoding to align with Go library

Signed-off-by: Prateek Malhotra <someone1@gmail.com>

Fixes #239 