### PR TITLE
Add EXPOSE to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 fake-gcs-server
+
+# editor and IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 fake-gcs-server
-
-# editor and IDE
-.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ RUN go build -o fake-gcs-server
 FROM alpine:3.11.6
 COPY --from=builder /code/fake-gcs-server /bin/fake-gcs-server
 RUN /bin/fake-gcs-server -h
+EXPOSE 4443
 ENTRYPOINT ["/bin/fake-gcs-server", "-data", "/data"]


### PR DESCRIPTION
## What is being changed

Add an `EXPOSE` command to the projects `Dockerfile`

## Why are we making this change?

In order to use the Docker image in CI pipelines, it's imperative that the `EXPOSE` command is in the `Dockerfile`. 

For example, see [How the health check of services works](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#how-the-health-check-of-services-works) from the Gitlab CI runner documentation. Specifically, the part which states:

> Checks which ports are exposed from the container by default

Without this, the pipeline will fail with an invalid host/port error. 

This change has also been published to [Docker Hub](https://hub.docker.com/repository/docker/omisnomis/fake-gcs-server) to prove that it now works as expected. 