### PR TITLE
Fix off-by-one error on NewRangeReader

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -395,9 +395,11 @@ func (s *Server) handleRange(obj Object, r *http.Request) (start, end int, conte
 			rangeParts := strings.SplitN(parts[1], "-", 2)
 			if len(rangeParts) == 2 {
 				start, _ = strconv.Atoi(rangeParts[0])
-				end, _ = strconv.Atoi(rangeParts[1])
-				if end < 1 {
+				var err error
+				if end, err = strconv.Atoi(rangeParts[1]); err != nil {
 					end = len(obj.Content)
+				} else {
+					end++
 				}
 				return start, end, obj.Content[start:end]
 			}


### PR DESCRIPTION
For Range request headers, per [RFC 7233](https://tools.ietf.org/html/rfc7233#section-4.2):

> `byte-range          = first-byte-pos "-" last-byte-pos`

In other words, the `byte-range` uses the `last-byte-pos`. This is subtly different than how Go slice indexing works [per the Go language spec](https://golang.org/ref/spec#Slice_expressions):

> The *indices* `low` and `high` select which elements of operand `a` appear in the result. The result has indices starting at 0 and length equal to `high - low`.

Therefore, we should take the `last-byte-pos` from the Range header and increment it by one to get the `high` that is expected by Go.

I created a test that illustrates the point.