### PR TITLE
Fix Range requests to correctly interpret last-byte-pos

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -395,9 +395,11 @@ func (s *Server) handleRange(obj Object, r *http.Request) (start, end int, conte
 			rangeParts := strings.SplitN(parts[1], "-", 2)
 			if len(rangeParts) == 2 {
 				start, _ = strconv.Atoi(rangeParts[0])
-				end, _ = strconv.Atoi(rangeParts[1])
-				if end < 1 {
+				var err error
+				if end, err = strconv.Atoi(rangeParts[1]); err != nil {
 					end = len(obj.Content)
+				} else {
+					end++
 				}
 				return start, end, obj.Content[start:end]
 			}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -339,9 +339,9 @@ func TestServerClientObjectRangeReader(t *testing.T) {
 			t.Run(test.testCase, func(t *testing.T) {
 				length := test.length
 				if length == -1 {
-					length = int64(len(content)) - test.offset + 1
+					length = int64(len(content)) - test.offset
 				}
-				expectedData := content[test.offset : test.offset+length-1]
+				expectedData := content[test.offset : test.offset+length]
 				client := server.Client()
 				objHandle := client.Bucket(bucketName).Object(objectName)
 				reader, err := objHandle.NewRangeReader(context.TODO(), test.offset, test.length)


### PR DESCRIPTION
I was having a problem with mocking `NewRangeReader`. My reads were giving me one-fewer bytes than I was expecting. I think I narrowed down why.

For Range request headers, per [RFC 7233](https://tools.ietf.org/html/rfc7233#section-4.2):

> `byte-range          = first-byte-pos "-" last-byte-pos`

In other words, the `byte-range` uses the `last-byte-pos`. This is subtly different than how Go slice indexing works [per the Go language spec](https://golang.org/ref/spec#Slice_expressions):

> The *indices* `low` and `high` select which elements of operand `a` appear in the result. The result has indices starting at 0 and length equal to `high - low`.

Therefore, we should take the `last-byte-pos` from the Range header and increment it by one to get the `high` that is expected by Go.

I created a test that illustrates the point. When I use the GCS `NewRangeReader` function, which has a `length` parameter, the old code would return `length-1` bytes.