### PR TITLE
Add check to ensure Range is less than content

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -401,6 +401,9 @@ func (s *Server) handleRange(obj Object, r *http.Request) (start, end int, conte
 				} else {
 					end++
 				}
+				if end > len(obj.Content) {
+					end = len(obj.Content)
+				}
 				return start, end, obj.Content[start:end]
 			}
 		}


### PR DESCRIPTION
* This fixes the case where a Range value greater than the length of the
  content is requested, causing the server to crash and fail the
  request.