### PR TITLE
add support for MD5 checksum of object content when using fs

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -97,9 +97,12 @@ func TestObjectCRUD(t *testing.T) {
 	const bucketName = "prod-bucket"
 	const objectName = "video/hi-res/best_video_1080p.mp4"
 	content1 := []byte("content1")
-	const crc1 = "crc1"
-	const md51 = "md51"
+	const crc1 = "syeM0w=="
+	const md51 = "flXbAB0xmpSwtxNSmnVmIw=="
 	content2 := []byte("content2")
+	const crc2 = "oHd/Jw=="
+	const md52 = "7qZw9KyUHfcaO18mjr4+rA=="
+
 	for _, versioningEnabled := range []bool{true, false} {
 		versioningEnabled := versioningEnabled
 		testForStorageBackends(t, func(t *testing.T, storage Storage) {
@@ -121,7 +124,7 @@ func TestObjectCRUD(t *testing.T) {
 			initialGeneration := uploadAndCompare(t, storage, initialObject)
 
 			t.Logf("create (update) in existent case with explicit generation and versioning %t", versioningEnabled)
-			secondVersionWithGeneration := Object{BucketName: bucketName, Name: objectName, Content: content2, Generation: 1234}
+			secondVersionWithGeneration := Object{BucketName: bucketName, Name: objectName, Content: content2, Generation: 1234, Crc32c: crc2, Md5Hash: md52}
 			uploadAndCompare(t, storage, secondVersionWithGeneration)
 
 			initialObjectFromGeneration, err := storage.GetObjectWithGeneration(initialObject.BucketName, initialObject.Name, initialGeneration)

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -5,9 +5,12 @@
 package backend
 
 import (
+	"crypto/md5" // #nosec G501
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -163,6 +166,37 @@ func (s *storageFS) GetObjectWithGeneration(bucketName, objectName string, gener
 	return Object{}, errors.New("not implemented: fs storage type does not support versioning yet")
 }
 
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+func crc32cChecksum(content []byte) []byte {
+	checksummer := crc32.New(crc32cTable)
+	checksummer.Write(content)
+	return checksummer.Sum(make([]byte, 0, 4))
+}
+
+func encodedChecksum(checksum []byte) string {
+	return base64.StdEncoding.EncodeToString(checksum)
+}
+
+func encodedCrc32cChecksum(content []byte) string {
+	return encodedChecksum(crc32cChecksum(content))
+}
+
+func md5Hash(b []byte) []byte {
+	/* #nosec G401 */
+	h := md5.New()
+	h.Write(b)
+	return h.Sum(nil)
+}
+
+func encodedHash(hash []byte) string {
+	return base64.StdEncoding.EncodeToString(hash)
+}
+
+func encodedMd5Hash(content []byte) string {
+	return encodedHash(md5Hash(content))
+}
+
 func (s *storageFS) getObject(bucketName, objectName string) (Object, error) {
 	encoded, err := ioutil.ReadFile(filepath.Join(s.rootDir, url.PathEscape(bucketName), url.PathEscape(objectName)))
 	if err != nil {
@@ -175,6 +209,8 @@ func (s *storageFS) getObject(bucketName, objectName string) (Object, error) {
 	}
 	obj.Name = filepath.ToSlash(objectName)
 	obj.BucketName = bucketName
+	obj.Crc32c = encodedCrc32cChecksum(obj.Content)
+	obj.Md5Hash = encodedMd5Hash(obj.Content)
 	return obj, nil
 }
 


### PR DESCRIPTION
Copy pasted md5 and crc hash functions from `upload.go`.

I compared the results against actually uploading to GCS (and using `gsutil hash -m`) and they differ for some reason. Whilst this is somewhat annoying it isn't a problem for me as all I need is something consistent.