### PR TITLE
Support CNAME'd buckets

### DIFF
--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io/ioutil"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -489,6 +490,46 @@ func TestServerClientObjectReaderError(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestServerClientObjectReadBucketCNAME(t *testing.T) {
+	url := "https://mybucket.mydomain.com:4443/files/txt/text-01.txt"
+	expectedHeaders := map[string]string{"accept-ranges": "bytes", "content-length": "9"}
+	expectedBody := "something"
+	opts := Options{
+		InitialObjects: []Object{
+			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
+		},
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := server.HTTPClient()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+	}
+	for k, expectedV := range expectedHeaders {
+		if v := resp.Header.Get(k); v != expectedV {
+			t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
+		}
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body := string(data); body != expectedBody {
+		t.Errorf("wrong body\nwant %q\ngot  %q", expectedBody, body)
+	}
 }
 
 func getObjectsForListTests() []Object {

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -184,12 +184,14 @@ func (s *Server) buildMuxer() {
 		r.Path("/b/{sourceBucket}/o/{sourceObject:.+}/rewriteTo/b/{destinationBucket}/o/{destinationObject:.+}").HandlerFunc(s.rewriteObject)
 	}
 
-	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	bucketHost := fmt.Sprintf("{bucketName}.%s", s.publicHost)
 	s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	s.mux.Path("/download/storage/v1/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.downloadObject)
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
+
+	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
+	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 
 	// Signed URL Uploads
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -194,6 +194,7 @@ func (s *Server) buildMuxer() {
 	// Signed URL Uploads
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)
 	s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)
+	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(s.insertObject)
 }
 
 // Stop stops the server, closing all connections.

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -6,9 +6,11 @@ package fakestorage
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -293,6 +295,93 @@ func TestDownloadObjectAlternatePublicHost(t *testing.T) {
 				t.Errorf("wrong body\nwant %q\ngot  %q", test.expectedBody, body)
 			}
 		})
+	}
+}
+
+func TestSignedUploadBucketCNAME(t *testing.T) {
+	url := "https://mybucket.mydomain.com:4443/files/txt/text-02.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=fake-gcs&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&X-Goog-Signature=fake-gc"
+	expectedName := "files/txt/text-02.txt"
+	expectedContentType := "text/plain"
+	expectedHash := "bHupxaFBQh4cA8uYB8l8dA=="
+	opts := Options{
+		InitialObjects: []Object{
+			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
+		},
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := server.HTTPClient()
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader("something else"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj Object
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj.Name != expectedName {
+		t.Errorf("wrong filename\nwant %q\ngot  %q", expectedName, obj.Name)
+	}
+	if obj.ContentType != expectedContentType {
+		t.Errorf("wrong content type\nwant %q\ngot  %q", expectedContentType, obj.ContentType)
+	}
+	if obj.Md5Hash != expectedHash {
+		t.Errorf("wrong md5 hash\nwant %q\ngot  %q", expectedHash, obj.Md5Hash)
+	}
+}
+
+func TestObjectDownloadBucketCNAME(t *testing.T) {
+	url := "https://mybucket.mydomain.com:4443/files/txt/text-01.txt"
+	expectedHeaders := map[string]string{"accept-ranges": "bytes", "content-length": "9"}
+	expectedBody := "something"
+	opts := Options{
+		InitialObjects: []Object{
+			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
+		},
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := server.HTTPClient()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+	}
+	for k, expectedV := range expectedHeaders {
+		if v := resp.Header.Get(k); v != expectedV {
+			t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
+		}
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body := string(data); body != expectedBody {
+		t.Errorf("wrong body\nwant %q\ngot  %q", expectedBody, body)
 	}
 }
 

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -6,11 +6,9 @@ package fakestorage
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 )
 
@@ -295,93 +293,6 @@ func TestDownloadObjectAlternatePublicHost(t *testing.T) {
 				t.Errorf("wrong body\nwant %q\ngot  %q", test.expectedBody, body)
 			}
 		})
-	}
-}
-
-func TestSignedUploadBucketCNAME(t *testing.T) {
-	url := "https://mybucket.mydomain.com:4443/files/txt/text-02.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=fake-gcs&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&X-Goog-Signature=fake-gc"
-	expectedName := "files/txt/text-02.txt"
-	expectedContentType := "text/plain"
-	expectedHash := "bHupxaFBQh4cA8uYB8l8dA=="
-	opts := Options{
-		InitialObjects: []Object{
-			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
-		},
-	}
-	server, err := NewServerWithOptions(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := server.HTTPClient()
-	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader("something else"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", "text/plain")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
-	}
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var obj Object
-	if err := json.Unmarshal(data, &obj); err != nil {
-		t.Fatal(err)
-	}
-	if obj.Name != expectedName {
-		t.Errorf("wrong filename\nwant %q\ngot  %q", expectedName, obj.Name)
-	}
-	if obj.ContentType != expectedContentType {
-		t.Errorf("wrong content type\nwant %q\ngot  %q", expectedContentType, obj.ContentType)
-	}
-	if obj.Md5Hash != expectedHash {
-		t.Errorf("wrong md5 hash\nwant %q\ngot  %q", expectedHash, obj.Md5Hash)
-	}
-}
-
-func TestObjectDownloadBucketCNAME(t *testing.T) {
-	url := "https://mybucket.mydomain.com:4443/files/txt/text-01.txt"
-	expectedHeaders := map[string]string{"accept-ranges": "bytes", "content-length": "9"}
-	expectedBody := "something"
-	opts := Options{
-		InitialObjects: []Object{
-			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
-		},
-	}
-	server, err := NewServerWithOptions(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := server.HTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
-	}
-	for k, expectedV := range expectedHeaders {
-		if v := resp.Header.Get(k); v != expectedV {
-			t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
-		}
-	}
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if body := string(data); body != expectedBody {
-		t.Errorf("wrong body\nwant %q\ngot  %q", expectedBody, body)
 	}
 }
 

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -299,6 +299,53 @@ func TestServerClientSignedUpload(t *testing.T) {
 	checkChecksum(t, []byte(data), obj)
 }
 
+func TestServerClientSignedUploadBucketCNAME(t *testing.T) {
+	url := "https://mybucket.mydomain.com:4443/files/txt/text-02.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=fake-gcs&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&X-Goog-Signature=fake-gc"
+	expectedName := "files/txt/text-02.txt"
+	expectedContentType := "text/plain"
+	expectedHash := "bHupxaFBQh4cA8uYB8l8dA=="
+	opts := Options{
+		InitialObjects: []Object{
+			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
+		},
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := server.HTTPClient()
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader("something else"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var obj Object
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj.Name != expectedName {
+		t.Errorf("wrong filename\nwant %q\ngot  %q", expectedName, obj.Name)
+	}
+	if obj.ContentType != expectedContentType {
+		t.Errorf("wrong content type\nwant %q\ngot  %q", expectedContentType, obj.ContentType)
+	}
+	if obj.Md5Hash != expectedHash {
+		t.Errorf("wrong md5 hash\nwant %q\ngot  %q", expectedHash, obj.Md5Hash)
+	}
+}
+
 func TestServerClientUploadWithPredefinedAclPublicRead(t *testing.T) {
 	server := NewServer(nil)
 	defer server.Stop()
@@ -464,93 +511,6 @@ func TestParseContentRange(t *testing.T) {
 				t.Fatalf("Expected err!=<nil>, but was %v", err)
 			}
 		})
-	}
-}
-
-func TestSignedUploadBucketCNAME(t *testing.T) {
-	url := "https://mybucket.mydomain.com:4443/files/txt/text-02.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=fake-gcs&X-Goog-Expires=3600&X-Goog-SignedHeaders=host&X-Goog-Signature=fake-gc"
-	expectedName := "files/txt/text-02.txt"
-	expectedContentType := "text/plain"
-	expectedHash := "bHupxaFBQh4cA8uYB8l8dA=="
-	opts := Options{
-		InitialObjects: []Object{
-			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
-		},
-	}
-	server, err := NewServerWithOptions(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := server.HTTPClient()
-	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader("something else"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", "text/plain")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
-	}
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var obj Object
-	if err := json.Unmarshal(data, &obj); err != nil {
-		t.Fatal(err)
-	}
-	if obj.Name != expectedName {
-		t.Errorf("wrong filename\nwant %q\ngot  %q", expectedName, obj.Name)
-	}
-	if obj.ContentType != expectedContentType {
-		t.Errorf("wrong content type\nwant %q\ngot  %q", expectedContentType, obj.ContentType)
-	}
-	if obj.Md5Hash != expectedHash {
-		t.Errorf("wrong md5 hash\nwant %q\ngot  %q", expectedHash, obj.Md5Hash)
-	}
-}
-
-func TestObjectDownloadBucketCNAME(t *testing.T) {
-	url := "https://mybucket.mydomain.com:4443/files/txt/text-01.txt"
-	expectedHeaders := map[string]string{"accept-ranges": "bytes", "content-length": "9"}
-	expectedBody := "something"
-	opts := Options{
-		InitialObjects: []Object{
-			{BucketName: "mybucket.mydomain.com", Name: "files/txt/text-01.txt", Content: []byte("something")},
-		},
-	}
-	server, err := NewServerWithOptions(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := server.HTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
-	}
-	for k, expectedV := range expectedHeaders {
-		if v := resp.Header.Get(k); v != expectedV {
-			t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
-		}
-	}
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if body := string(data); body != expectedBody {
-		t.Errorf("wrong body\nwant %q\ngot  %q", expectedBody, body)
 	}
 }
 


### PR DESCRIPTION
I was having some issues interfacing with `fake-gcs-server` for buckets behind a CNAME, where the bucket name is the host itself. It seems as though only Path based (`storage.googleapis.com/myBucketName`) or VHost based (`myBucketName.storage.googleapis.com`) are supported.

This small fix addresses the issue by providing additional routes which consider the host as a bucket name; one for GETing a file and another for Signed URLs.

I also had to shuffle the route order slightly to prevent routes from conflicting.