### PR TITLE
Lock linter version to fix new failures.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: golangci/golangci-lint-action@v2.3.0
+        with:
+          version: v1.32
 
   build:
     name: build-and-publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 ADD . ./
 RUN go test -race -vet all -mod readonly ./...
 
-FROM golangci/golangci-lint AS linter
+FROM golangci/golangci-lint:v1.32 AS linter
 WORKDIR /code
 ENV GOPROXY=off
 COPY --from=tester /go/pkg /go/pkg


### PR DESCRIPTION
Lock the linter to version v1.32 to prevent failures on more recent linter versions. This gets the main branch building again and would isolate future lint cleanups.

Grabbed change from #370 