### PR TITLE
Disable gzipped responses

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 
 	"cloud.google.com/go/storage"
-	"github.com/NYTimes/gziphandler"
 	"github.com/fsouza/fake-gcs-server/internal/backend"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -121,7 +120,6 @@ func NewServerWithOptions(options Options) (*Server, error) {
 	if options.Writer != nil {
 		handler = handlers.LoggingHandler(options.Writer, handler)
 	}
-	handler = gziphandler.GzipHandler(handler)
 	handler = requestCompressHandler(handler)
 	if options.NoListener {
 		s.setTransportToMux(handler)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/fsouza/fake-gcs-server
 
 require (
 	cloud.google.com/go/storage v1.13.0
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/google/go-cmp v0.5.4
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ cloud.google.com/go/storage v1.13.0/go.mod h1:pqFyBUK3zZqMIIU5+8NaZq6/Ma3ClgUg9H
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -147,7 +145,6 @@ github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=


### PR DESCRIPTION
The Java SDK sends gzipped requests, and some clients will send the
appropriate accept headers, but we don't _need_ to send gzipped
responses. This makes the server simpler and easier to debug. Plus,
supporting the Java SDK doesn't require gzipped responses.

The idea here is to debug and potentially use this as the fix for #419.
This should have no effect on gzipped _requests_.