### PR TITLE
add put method for object updates

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -201,7 +201,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b/{bucketName}").Methods("GET").HandlerFunc(s.getBucket)
 		r.Path("/b/{bucketName}/o").Methods("GET").HandlerFunc(s.listObjects)
 		r.Path("/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
-		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("PATCH").HandlerFunc(s.patchObject)
+		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("PATCH", "PUT").HandlerFunc(s.patchObject)
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods("GET").HandlerFunc(s.listObjectACL)
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl/{entity}").Methods("PUT").HandlerFunc(s.setObjectACL)
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.getObject)


### PR DESCRIPTION
GCS has `PUT` method to object updates. Under the hood fake-gcs-server uses `Update` method from Google but this call `PUT` request instead of `PATCH` and fake-gcs-server serves only `PATCH`, then for consistency I've added `PUT` method also.