### PR TITLE
Add delete routes

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -215,7 +215,8 @@ func (s *Server) buildMuxer() {
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
 
-    s.mux.Host(bucketHost).Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
+    s.mux.Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
+    s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -214,6 +214,9 @@ func (s *Server) buildMuxer() {
 	s.mux.Path("/download/storage/v1/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.downloadObject)
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
+    
+    s.mux.Path("/b/{bucketName}/o").Methods("GET").HandlerFunc(s.listObjects)
+    s.mux.Host(bucketHost).Methods("GET").HandlerFunc(s.listObjects)
 
     s.mux.Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
     s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -215,6 +215,7 @@ func (s *Server) buildMuxer() {
 	s.mux.Path("/upload/storage/v1/b/{bucketName}/o").Methods("POST").HandlerFunc(s.insertObject)
 	s.mux.Path("/upload/resumable/{uploadId}").Methods("PUT", "POST").HandlerFunc(s.uploadFileContent)
 
+    s.mux.Host(bucketHost).Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(s.deleteObject)
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kmgreen2/fake-gcs-server
+module github.com/fsouza/fake-gcs-server
 
 require (
 	cloud.google.com/go/storage v1.14.0
@@ -9,4 +9,4 @@ require (
 	google.golang.org/api v0.40.0
 )
 
-go 1.15
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fsouza/fake-gcs-server
+module github.com/kmgreen2/fake-gcs-server
 
 require (
 	cloud.google.com/go/storage v1.14.0


### PR DESCRIPTION
I am not sure if others are hitting this, but I consistently got 405 whenever I tried issuing deletes using the official Golang GCS SDK.

Looking closer at the code, it seems like some of the routers are not in use?  In `buildMuxer()` (server.go:189), I see that `routers` is allocated, but never used.  Furthermore, I only see the routers defined on server.go:213 through server.go:225 when inspecting/debugging mux.go:136 (`mux:v1.8.0`).

What is the intention of `server.go:198`?  Should that be removed, or am I missing a side-effect.  If there is a side-effect associated with routers, I would suggest you directly define those routes.

In any case, deletes are returning a 405 because the server cannot find a route.  Since I am not sure of the intention of `server.go:198`, I have added new delete routes directly to `s.mux`, which fixes the issue.
 