### PR TITLE
Add json content-type to get object route

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -396,6 +396,7 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Content-Type", "application/json")
 	encoder.Encode(newObjectResponse(obj))
 }
 


### PR DESCRIPTION
I faced the [same problem](https://github.com/fsouza/fake-gcs-server/issues/451) with a ruby client, added one more fix