### PR TITLE
adds support for deleting buckets

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -187,6 +187,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b").Methods("GET").HandlerFunc(jsonToHTTPHandler(s.listBuckets))
 		r.Path("/b").Methods("POST").HandlerFunc(jsonToHTTPHandler(s.createBucketByPost))
 		r.Path("/b/{bucketName}").Methods("GET").HandlerFunc(jsonToHTTPHandler(s.getBucket))
+		r.Path("/b/{bucketName}").Methods("DELETE").HandlerFunc(jsonToHTTPHandler(s.deleteBucket))
 		r.Path("/b/{bucketName}/o").Methods("GET").HandlerFunc(jsonToHTTPHandler(s.listObjects))
 		r.Path("/b/{bucketName}/o").Methods("POST").HandlerFunc(jsonToHTTPHandler(s.insertObject))
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("PATCH").HandlerFunc(jsonToHTTPHandler(s.patchObject))

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -193,7 +193,7 @@ func TestObjectQueryErrors(t *testing.T) {
 	}
 }
 
-func TestBucketCreateGetList(t *testing.T) {
+func TestBucketCreateGetListDelete(t *testing.T) {
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		buckets, err := storage.ListBuckets()
 		if err != nil {
@@ -206,7 +206,7 @@ func TestBucketCreateGetList(t *testing.T) {
 			{"prod-bucket", false, time.Time{}},
 			{"prod-bucket-with-versioning", true, time.Time{}},
 		}
-		for i, bucket := range bucketsToTest {
+		for _, bucket := range bucketsToTest {
 			_, err := storage.GetBucket(bucket.Name)
 			if err == nil {
 				t.Fatalf("bucket %s, exists before being created", bucket.Name)
@@ -238,17 +238,15 @@ func TestBucketCreateGetList(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(buckets) != i+1 {
-				t.Errorf("number of buckets does not match the times we have lopped. Expected %d, found %d", i, len(buckets))
+			if len(buckets) != 1 {
+				t.Errorf("found unexpected number of buckets. Expected 1, found %d", len(buckets))
 			}
-			found := false
-			for _, listedBucket := range buckets {
-				if listedBucket.Name == bucket.Name {
-					found = true
-				}
+			if buckets[0].Name != bucket.Name {
+				t.Errorf("listed bucket has unexpected name. Expected %s, actual: %v", bucket.Name, buckets[0].Name)
 			}
-			if !found {
-				t.Errorf("Bucket we have just created is not part of the bucket listing. Expected %s, results: %v", bucket.Name, buckets)
+			err = storage.DeleteBucket(bucket.Name)
+			if err != nil {
+				t.Fatal(err)
 			}
 		}
 	})

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -160,6 +160,22 @@ func (s *storageMemory) getBucketInMemory(name string) (bucketInMemory, error) {
 	return bucketInMemory{}, fmt.Errorf("no bucket named %s", name)
 }
 
+// DeleteBucket removes the bucket from the backend.
+func (s *storageMemory) DeleteBucket(name string) error {
+	objs, err := s.ListObjects(name, false)
+	if err != nil {
+		return BucketNotFound
+	}
+	if len(objs) > 0 {
+		return BucketNotEmpty
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	delete(s.buckets, name)
+	return nil
+}
+
 // CreateObject stores an object in the backend.
 func (s *storageMemory) CreateObject(obj Object) (Object, error) {
 	s.mtx.Lock()

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -11,6 +11,7 @@ type Storage interface {
 	CreateBucket(name string, versioningEnabled bool) error
 	ListBuckets() ([]Bucket, error)
 	GetBucket(name string) (Bucket, error)
+	DeleteBucket(name string) error
 	CreateObject(obj Object) (Object, error)
 	ListObjects(bucketName string, versions bool) ([]Object, error)
 	GetObject(bucketName, objectName string) (Object, error)
@@ -18,3 +19,10 @@ type Storage interface {
 	DeleteObject(bucketName, objectName string) error
 	PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error)
 }
+
+type Error string
+
+func (e Error) Error() string { return string(e) }
+
+const BucketNotFound = Error("bucket not found")
+const BucketNotEmpty = Error("bucket must be empty prior to deletion")


### PR DESCRIPTION
This PR adds support for deleting buckets with the gcs client. I do not know the full set of preconditions for deleting a bucket, but GCS does require the bucket to be empty, which is respected here.

This fixes https://github.com/fsouza/fake-gcs-server/issues/214