### PR TITLE
Fix nodeJS file upload (issue #346)

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -380,11 +380,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 			commit = parsed.KnownTotal && (parsed.End+1 >= parsed.Total)
 		} else {
 			// End of a streaming request
-			contentLength := 0
-			if obj.Content != nil {
-				contentLength = len(obj.Content)
-			}
-			responseHeader.Set("Range", fmt.Sprintf("bytes=0-%d", contentLength))
+			responseHeader.Set("Range", fmt.Sprintf("bytes=0-%d", len(obj.Content)))
 		}
 	}
 	if commit {

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -488,6 +488,10 @@ func TestParseContentRange(t *testing.T) {
 			contentRange{KnownTotal: true, Start: -1, End: -1, Total: 1024},
 		},
 		{
+			"bytes 0-*/*", // Start and end of a streaming request as done by nodeJS client lib
+			contentRange{KnownTotal: false, Start: 0, End: -1, Total: -1},
+		},
+		{
 			"bytes 1024-2047/4096", // Range with a known total
 			contentRange{KnownRange: true, KnownTotal: true, Start: 1024, End: 2047, Total: 4096},
 		},


### PR DESCRIPTION
As https://github.com/fsouza/fake-gcs-server/issues/346 states, there is a bug when uploading files with the nodeJS client lib.

I debugged it and the problem is, that nodeJS sends `Content-Range: bytes 0-*/*` (see https://github.com/googleapis/gcs-resumable-upload/blob/master/src/index.ts#L456).

I could not really find a good documentation on the exact semantics but from observing the client lib I guess it means "start and end upload stream with all the data I provide you". I adjusted the code accordingly and added a test case. I also checked that the following node example works fine:

```javascript
async function saveFile() {
  // [START storage_list_buckets]
  // Imports the Google Cloud client library
  const { Storage } = require("@google-cloud/storage");

  // Creates a client
  const storage = new Storage({
    apiEndpoint: "http://localhost:8080",
    projectId: "test",
  });

  const bucket = await storage.createBucket("testbucket");
  const file = new File(bucket, "test.txt");
  await file.save("abc", { contentType: "text/plain" });
  // [END storage_list_buckets]
}

saveFile().catch((err) => {
  console.error(err);
  process.exit(1);
});
```