### PR TITLE
added POST endpoint for acls

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -192,6 +192,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b/{bucketName}/o").Methods("POST").HandlerFunc(jsonToHTTPHandler(s.insertObject))
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("PATCH").HandlerFunc(jsonToHTTPHandler(s.patchObject))
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods("GET").HandlerFunc(jsonToHTTPHandler(s.listObjectACL))
+		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods("POST").HandlerFunc(jsonToHTTPHandler(s.setObjectACL))
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl/{entity}").Methods("PUT").HandlerFunc(jsonToHTTPHandler(s.setObjectACL))
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("GET").HandlerFunc(s.getObject)
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods("DELETE").HandlerFunc(jsonToHTTPHandler(s.deleteObject))


### PR DESCRIPTION
Besides the `PATCH` for object-level ACLs, there is also a `POST`: https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls/insert

It is called for example by the nodeJS lib when calling `file.makePublic()`.

I added the endpoint and reused the `PATCH` code. I suspect the code is actually correct for `POST` but might be incomplete for `PATCH`. Anyhow, with this PR `file.makePublic()` works like a charm.

