### PR TITLE
Add CRC32 and MD5 hashes for preseeded files

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -119,8 +119,8 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 		Content:         data,
 		ContentType:     r.Header.Get(contentTypeHeader),
 		ContentEncoding: contentEncoding,
-		Crc32c:          encodedCrc32cChecksum(data),
-		Md5Hash:         encodedMd5Hash(data),
+		Crc32c:          EncodedCrc32cChecksum(data),
+		Md5Hash:         EncodedMd5Hash(data),
 		ACL:             getObjectACL(predefinedACL),
 	}
 	obj, err = s.createObject(obj)
@@ -159,8 +159,8 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 		Content:         data,
 		ContentType:     r.Header.Get(contentTypeHeader),
 		ContentEncoding: contentEncoding,
-		Crc32c:          encodedCrc32cChecksum(data),
-		Md5Hash:         encodedMd5Hash(data),
+		Crc32c:          EncodedCrc32cChecksum(data),
+		Md5Hash:         EncodedMd5Hash(data),
 		ACL:             getObjectACL(predefinedACL),
 		Metadata:        metaData,
 	}
@@ -201,7 +201,7 @@ func encodedChecksum(checksum []byte) string {
 	return base64.StdEncoding.EncodeToString(checksum)
 }
 
-func encodedCrc32cChecksum(content []byte) string {
+func EncodedCrc32cChecksum(content []byte) string {
 	return encodedChecksum(crc32cChecksum(content))
 }
 
@@ -216,7 +216,7 @@ func encodedHash(hash []byte) string {
 	return base64.StdEncoding.EncodeToString(hash)
 }
 
-func encodedMd5Hash(content []byte) string {
+func EncodedMd5Hash(content []byte) string {
 	return encodedHash(md5Hash(content))
 }
 
@@ -268,8 +268,8 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		Content:         content,
 		ContentType:     contentType,
 		ContentEncoding: metadata.ContentEncoding,
-		Crc32c:          encodedCrc32cChecksum(content),
-		Md5Hash:         encodedMd5Hash(content),
+		Crc32c:          EncodedCrc32cChecksum(content),
+		Md5Hash:         EncodedMd5Hash(content),
 		ACL:             getObjectACL(predefinedACL),
 		Metadata:        metadata.Metadata,
 	}
@@ -364,8 +364,8 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	commit := true
 	status := http.StatusOK
 	obj.Content = append(obj.Content, content...)
-	obj.Crc32c = encodedCrc32cChecksum(obj.Content)
-	obj.Md5Hash = encodedMd5Hash(obj.Content)
+	obj.Crc32c = EncodedCrc32cChecksum(obj.Content)
+	obj.Md5Hash = EncodedMd5Hash(obj.Content)
 	obj.ContentType = r.Header.Get(contentTypeHeader)
 	responseHeader := make(http.Header)
 	if contentRange := r.Header.Get("Content-Range"); contentRange != "" {

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -120,7 +120,7 @@ func TestServerClientObjectWriter(t *testing.T) {
 
 func checkChecksum(t *testing.T, content []byte, obj Object) {
 	t.Helper()
-	if expect := encodedCrc32cChecksum(content); expect != obj.Crc32c {
+	if expect := EncodedCrc32cChecksum(content); expect != obj.Crc32c {
 		t.Errorf("wrong checksum in the object\nwant %s\ngot  %s", expect, obj.Crc32c)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func objectsFromBucket(localBucketPath, bucketName string) ([]fakestorage.Object
 				BucketName: bucketName,
 				Name:       objectKey,
 				Content:    fileContent,
+				Crc32c:     fakestorage.EncodedCrc32cChecksum(fileContent),
+				Md5Hash:    fakestorage.EncodedMd5Hash(fileContent),
 			})
 		}
 		return nil


### PR DESCRIPTION
This patch adds CRC32 and MD5 hashes for files preloaded from the seed directory. I believe this closes the issue https://github.com/fsouza/fake-gcs-server/issues/313

I haven't noticed any preexisting tests for this functionality so I only tested the patch manually. Probably it makes sense to move CRC32 and MD5 functions out of upload.go into a separate file as they are now used in multiple places but I didn't do this to keep the patch small.