### PR TITLE
Add form data upload

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -279,9 +279,6 @@ func requestCompressHandler(h http.Handler) http.Handler {
 }
 
 func matchFormData(r *http.Request, _ *mux.RouteMatch) bool {
-	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if err != nil {
-		return false
-	}
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	return contentType == "multipart/form-data"
 }

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -209,6 +210,10 @@ func (s *Server) buildMuxer() {
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods("GET", "HEAD").HandlerFunc(s.downloadObject)
 
+	// Form Uploads
+	s.mux.Host(s.publicHost).Path("/{bucketName}").MatcherFunc(matchFormData).Methods("POST", "PUT").HandlerFunc(xmlToHTTPHandler(s.insertFormObject))
+	s.mux.Host(bucketHost).MatcherFunc(matchFormData).Methods("POST", "PUT").HandlerFunc(xmlToHTTPHandler(s.insertFormObject))
+
 	// Signed URL Uploads
 	s.mux.Host(s.publicHost).Path("/{bucketName}/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(jsonToHTTPHandler(s.insertObject))
 	s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods("POST", "PUT").HandlerFunc(jsonToHTTPHandler(s.insertObject))
@@ -271,4 +276,12 @@ func requestCompressHandler(h http.Handler) http.Handler {
 		}
 		h.ServeHTTP(w, r)
 	})
+}
+
+func matchFormData(r *http.Request, _ *mux.RouteMatch) bool {
+	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return contentType == "multipart/form-data"
 }

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 	"strings"
@@ -652,6 +653,91 @@ func TestServerGzippedUpload(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestFormDataUpload(t *testing.T) {
+	server, err := NewServerWithOptions(Options{PublicHost: "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("could not start server: %v", err)
+	}
+	defer server.Stop()
+	server.CreateBucketWithOpts(CreateBucketOpts{Name: "other-bucket"})
+
+	var buf bytes.Buffer
+	const content = "some weird content"
+	const contentType = "text/plain"
+	writer := multipart.NewWriter(&buf)
+
+	var fieldWriter io.Writer
+	if fieldWriter, err = writer.CreateFormField("key"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fieldWriter.Write([]byte("object.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	if fieldWriter, err = writer.CreateFormField("Content-Type"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fieldWriter.Write([]byte(contentType)); err != nil {
+		t.Fatal(err)
+	}
+
+	if fieldWriter, err = writer.CreateFormField("x-goog-meta-key"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fieldWriter.Write([]byte("Value")); err != nil {
+		t.Fatal(err)
+	}
+
+
+	if fieldWriter, err = writer.CreateFormFile("file", "object.txt"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fieldWriter.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", server.URL()+"/other-bucket", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Content-Type",  writer.FormDataContentType())
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	expectedStatus := http.StatusNoContent
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
+	}
+
+	obj, err := server.GetObject("other-bucket", "object.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(obj.Content) != content {
+		t.Errorf("wrong content\nwant %q\ngot  %q", string(obj.Content), content)
+	}
+	if obj.ContentType != contentType {
+		t.Errorf("wrong content type\nwant %q\ngot  %q", contentType, obj.ContentType)
+	}
+	if want := map[string]string{"key": "Value"}; !reflect.DeepEqual(obj.Metadata, want) {
+		t.Errorf("wrong metadata\nwant %q\ngot  %q", want, obj.Metadata)
+	}
+	checkChecksum(t, []byte(content), obj)
 }
 
 func isACLPublic(acl []storage.ACLRule) bool {

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -690,7 +690,6 @@ func TestFormDataUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
 	if fieldWriter, err = writer.CreateFormFile("file", "object.txt"); err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +707,7 @@ func TestFormDataUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req.Header.Set("Content-Type",  writer.FormDataContentType())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 	client := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/fakestorage/xml_response.go
+++ b/fakestorage/xml_response.go
@@ -1,0 +1,55 @@
+package fakestorage
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+type xmlResponse struct {
+	status       int
+	header       http.Header
+	data         interface{}
+	errorMessage string
+}
+
+type xmlHandler = func(r *http.Request) xmlResponse
+
+func xmlToHTTPHandler(h xmlHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := h(r)
+		w.Header().Set("Content-Type", "application/xml")
+		for name, values := range resp.header {
+			for _, value := range values {
+				w.Header().Add(name, value)
+			}
+		}
+
+		status := resp.getStatus()
+		var data interface{}
+		if status > 399 {
+			data = newErrorResponse(status, resp.getErrorMessage(status), nil)
+		} else {
+			data = resp.data
+		}
+
+		w.WriteHeader(status)
+		xml.NewEncoder(w).Encode(data)
+	}
+}
+
+func (r *xmlResponse) getStatus() int {
+	if r.status > 0 {
+		return r.status
+	}
+	if r.errorMessage != "" {
+		return http.StatusInternalServerError
+	}
+	return http.StatusOK
+}
+
+func (r *xmlResponse) getErrorMessage(status int) string {
+	if r.errorMessage != "" {
+		return r.errorMessage
+	}
+	return http.StatusText(status)
+}


### PR DESCRIPTION
Closes https://github.com/fsouza/fake-gcs-server/issues/270

This adds the form data upload method that is commonly used for websites. It does the basic, but could be extended to support further use cases down the line. I tried to follow the current code architecture as much as I could.