### PR TITLE
Add file download to node example

### DIFF
--- a/examples/node/docker-compose.yaml
+++ b/examples/node/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  storage:
+    image: fsouza/fake-gcs-server
+    build: ../../
+    ports:
+      - 8080:8080
+    volumes:
+      - ../data:/data
+    command: ["-scheme", "http", "-port", "8080", "-external-url", "http://localhost:8080", "-backend", "memory"]

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -17,11 +17,13 @@ async function run() {
   });
   // [END storage_list_buckets]
 
-  const response = await storage.bucket('sample-bucket')
+  const [content] = await storage.bucket('sample-bucket')
     .file('some_file.txt')
-    .download();
+    .download({
+      validation: false // FIXME
+    });
   console.log("Contents:")
-  console.log(response)
+  console.log(content.toString())
 }
 
 

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -20,7 +20,7 @@ async function run() {
   const [content] = await storage.bucket('sample-bucket')
     .file('some_file.txt')
     .download({
-      validation: false // FIXME
+      // validation: false // FIXME: needed when x-goog-hash header isn't present on the response
     });
   console.log("Contents:")
   console.log(content.toString())

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -1,4 +1,4 @@
-async function listBuckets() {
+async function run() {
   // [START storage_list_buckets]
   // Imports the Google Cloud client library
   const { Storage } = require("@google-cloud/storage");
@@ -16,9 +16,16 @@ async function listBuckets() {
     console.log(bucket.id);
   });
   // [END storage_list_buckets]
+
+  const response = await storage.bucket('sample-bucket')
+    .file('some_file.txt')
+    .download();
+  console.log("Contents:")
+  console.log(response)
 }
 
-listBuckets().catch((err) => {
+
+run().catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -19,9 +19,7 @@ async function run() {
 
   const [content] = await storage.bucket('sample-bucket')
     .file('some_file.txt')
-    .download({
-      // validation: false // FIXME: needed when x-goog-hash header isn't present on the response
-    });
+    .download();
   console.log("Contents:")
   console.log(content.toString())
 }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "run": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -562,8 +562,7 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 	w.Header().Set(contentTypeHeader, obj.ContentType)
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
-	w.Header().Set("X-Goog-Hash", fmt.Sprintf("crc32c=%s", obj.Crc32c))
-	// w.Header().Set("X-Goog-Hash", fmt.Sprintf("md5=%s", obj.Md5Hash))
+	w.Header().Set("X-Goog-Hash", fmt.Sprintf("crc32c=%s,md5=%s", obj.Crc32c, obj.Md5Hash))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))
 	if obj.ContentEncoding != "" {
 		w.Header().Set("Content-Encoding", obj.ContentEncoding)

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -562,6 +562,8 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 	w.Header().Set(contentTypeHeader, obj.ContentType)
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
+	w.Header().Set("X-Goog-Hash", fmt.Sprintf("crc32c=%s", obj.Crc32c))
+	// w.Header().Set("X-Goog-Hash", fmt.Sprintf("md5=%s", obj.Md5Hash))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))
 	if obj.ContentEncoding != "" {
 		w.Header().Set("Content-Encoding", obj.ContentEncoding)

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -558,9 +558,11 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusPartialContent
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(obj.Content)))
 	}
+	if obj.ContentType != "" {
+		w.Header().Set(contentTypeHeader, obj.ContentType)
+	}
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("Content-Length", strconv.Itoa(len(content)))
-	w.Header().Set(contentTypeHeader, obj.ContentType)
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("X-Goog-Hash", fmt.Sprintf("crc32c=%s,md5=%s", obj.Crc32c, obj.Md5Hash))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))


### PR DESCRIPTION
* Use `docker-compose.yaml` to start the `fake-gcs` service (copied from the `dotnet` example, with the addition of a `build` path and a `volumes` mount to load the example data).
* Add an example of downloading a file from a bucket.

The `download` example is currently failing when used with `@google-cloud/storage` > v5.8.1 unless `validation: false` is set, which isn't ideal - it seems that `fake-gcs` needs to be setting a `x-goog-hash` header on the response. 

I've added a line of code that sets `X-Goog-Hash` on the download response, but I'm not sure when either of `obj.Crc32c` or `obj.Md5Hash` are guaranteed to be set on the object, so someone with more knowledge of the server will need to finish this off.

Closes #529.
