### PR TITLE
Map errors to HTTP statuses

### DIFF
--- a/fakestorage/json_response.go
+++ b/fakestorage/json_response.go
@@ -2,7 +2,10 @@ package fakestorage
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
+	"syscall"
 )
 
 type jsonResponse struct {
@@ -52,4 +55,13 @@ func (r *jsonResponse) getErrorMessage(status int) string {
 		return r.errorMessage
 	}
 	return http.StatusText(status)
+}
+
+func errToJsonResponse(err error) jsonResponse {
+	status := 0
+	var pathError *os.PathError
+	if errors.As(err, &pathError) && pathError.Err == syscall.ENAMETOOLONG {
+		status = http.StatusBadRequest
+	}
+	return jsonResponse{errorMessage: err.Error(), status: status}
 }

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -556,7 +556,10 @@ func (s *Server) setObjectACL(r *http.Request) jsonResponse {
 		Role:   role,
 	}}
 
-	s.CreateObject(obj)
+	_, err = s.createObject(obj)
+	if err != nil {
+		return errToJsonResponse(err)
+	}
 
 	return jsonResponse{data: newACLListResponse(obj.ObjectAttrs)}
 }
@@ -607,7 +610,11 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 		Content: append([]byte(nil), obj.Content...),
 	}
 
-	s.CreateObject(newObject)
+	_, err = s.createObject(newObject)
+	if err != nil {
+		return errToJsonResponse(err)
+	}
+
 	return jsonResponse{data: newObjectRewriteResponse(newObject.ObjectAttrs)}
 }
 

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -196,7 +196,7 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 	}
 	obj, err = s.createObject(obj)
 	if err != nil {
-		return jsonResponse{errorMessage: err.Error()}
+		return errToJsonResponse(err)
 	}
 	return jsonResponse{data: obj}
 }
@@ -239,7 +239,7 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 	}
 	obj, err = s.createObject(obj)
 	if err != nil {
-		return jsonResponse{errorMessage: err.Error()}
+		return errToJsonResponse(err)
 	}
 	return jsonResponse{data: obj}
 }
@@ -319,7 +319,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 	}
 	obj, err = s.createObject(obj)
 	if err != nil {
-		return jsonResponse{errorMessage: err.Error()}
+		return errToJsonResponse(err)
 	}
 	return jsonResponse{data: obj}
 }
@@ -433,7 +433,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 		s.uploads.Delete(uploadID)
 		obj, err = s.createObject(obj)
 		if err != nil {
-			return jsonResponse{errorMessage: err.Error()}
+			return errToJsonResponse(err)
 		}
 	} else {
 		if _, no308 := r.Header["X-Guploader-No-308"]; no308 {


### PR DESCRIPTION
The initial motivation is to map `ENAMETOOLONG` from 500 Internal Error
to 400 Bad Request.  This prevents clients like gcsfuse from
unnecessarily retrying requests.  This commit also remove some panic
call paths.