### PR TITLE
Store object metadata and data separately

### DIFF
--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -40,5 +40,5 @@ func (o *ObjectAttrs) IDNoGen() string {
 // Object represents the object that is stored within the fake server.
 type Object struct {
 	ObjectAttrs
-	Content []byte
+	Content []byte `json:"-"`
 }


### PR DESCRIPTION
The former remains a JSON-encoded blob while the latter is stored in its
native format.  This reduces memory usage and is much faster by avoiding
JSON-encoding large objects.  This enables a future commit to avoid
reading the entire object, particularly for range requests.  Note that
this commit changes the on-disk format and is not compatible with
previous data sets.  References #669.  Fixes #671.