### PR TITLE
Write to byte buffer first, then to response

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/internal/backend"
 	"github.com/fsouza/fake-gcs-server/internal/notification"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -23,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/internal/backend"
 	"github.com/fsouza/fake-gcs-server/internal/notification"

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -10,7 +10,9 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io"
+	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net"
@@ -308,7 +310,8 @@ func (s *Server) handleBatchCall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mw := multipart.NewWriter(w)
+	var b bytes.Buffer
+	mw := multipart.NewWriter(&b)
 	defer mw.Close()
 	w.Header().Set("Content-Type", "multipart/mixed; boundary="+mw.Boundary())
 
@@ -337,7 +340,8 @@ func (s *Server) handleBatchCall(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		content, err := loadContent(part)
+		content, err := ioutil.ReadAll(part)
+		part.Close()
 		if err != nil {
 			http.Error(partResponseWriter, "unable to process request", http.StatusBadRequest)
 			writeMultipartResponse(partResponseWriter.Result(), partWriter, contentID)
@@ -353,6 +357,13 @@ func (s *Server) handleBatchCall(w http.ResponseWriter, r *http.Request) {
 
 		s.mux.ServeHTTP(partResponseWriter, partRequest)
 		writeMultipartResponse(partResponseWriter.Result(), partWriter, contentID)
+	}
+	mw.Close()
+
+	_, err = b.WriteTo(w)
+	if err != nil {
+		logrus.New().Error(err)
+		http.Error(w, "unable to process request", http.StatusBadRequest)
 	}
 }
 


### PR DESCRIPTION
I've ran into an issue where parts of the request could not be read, because the response writer was already close, as we were already writing stuff into it before.
The solution is to write into a byte buffer instead, and write that out in the end into the response.