### PR TITLE
Add signed URL setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ curl http://0.0.0.0:4443/storage/v1/b/sample-bucket/o
 
 ### Using with signed URLs
 
-It is possible to use fake-gcs-server with signed URLs, although with a few caveats :
+It is possible to use fake-gcs-server with signed URLs, although with a few caveats:
+
 * No validation is made on the query params (signature, expiration ...)
 * You need your client to modify the URL before passing it around (replacing `storage.googleapis.com` by something that will point to fake-gcs-server)
 * You need to configure fake-gcs-server to accept this local URL

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ curl http://0.0.0.0:4443/storage/v1/b/sample-bucket/o
 {"kind":"storage#objects","items":[{"kind":"storage#object","name":"some_file.txt","id":"sample-bucket/some_file.txt","bucket":"sample-bucket","size":"33"}],"prefixes":[]}
 ```
 
+### Using with signed URLs
+
+It is possible to use fake-gcs-server with signed URLs, although with a few caveats :
+* No validation is made on the query params (signature, expiration ...)
+* You need your client to modify the URL before passing it around (replacing `storage.googleapis.com` by something that will point to fake-gcs-server)
+* You need to configure fake-gcs-server to accept this local URL
+
+Here is an example of such a configuration :
+```shell
+docker run -d --name fake-gcs-server -p 4443:4443 fsouza/fake-gcs-server -public-host storage.googleapis.localhost:4443
+```
+
 ## Client library examples
 
 For examples using SDK from multiple languages, check out the

--- a/README.md
+++ b/README.md
@@ -78,15 +78,11 @@ curl http://0.0.0.0:4443/storage/v1/b/sample-bucket/o
 
 It is possible to use fake-gcs-server with signed URLs, although with a few caveats:
 
-* No validation is made on the query params (signature, expiration ...)
-* You need your client to modify the URL before passing it around (replacing `storage.googleapis.com` by something that will point to fake-gcs-server)
-* You need to configure fake-gcs-server to accept this local URL
-
-Here is an example of such a configuration:
-
-```shell
-docker run -d --name fake-gcs-server -p 4443:4443 fsouza/fake-gcs-server -public-host storage.googleapis.localhost:4443
-```
+- No validation is made on the query params (signature, expiration ...)
+- You need your client to modify the URL before passing it around (replace
+  `storage.googleapis.com` with something that points to fake-gcs-server)
+- You need to configure fake-gcs-server to accept this local URL (by setting
+  `-public-host`)
 
 ## Client library examples
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ It is possible to use fake-gcs-server with signed URLs, although with a few cave
 * You need your client to modify the URL before passing it around (replacing `storage.googleapis.com` by something that will point to fake-gcs-server)
 * You need to configure fake-gcs-server to accept this local URL
 
-Here is an example of such a configuration :
+Here is an example of such a configuration:
+
 ```shell
 docker run -d --name fake-gcs-server -p 4443:4443 fsouza/fake-gcs-server -public-host storage.googleapis.localhost:4443
 ```


### PR DESCRIPTION
Hi !

First of all, thanks for providing this project ! It proved very useful :)


I found however the documentation on the required setup for use with signed URLs insufficient, and had to dig quite a bit in the code to understand how to make it work.

Here's a minimal doc addition explaining how to do it.

You might want to change the structure, such as adding it out of the docker section instead, including it in code samples, etc ...

Related issues : https://github.com/fsouza/fake-gcs-server/issues/631 https://github.com/fsouza/fake-gcs-server/issues/537

Closes #631.