### PR TITLE
upload: restore behavior when ifGenerationMatch=0 for the fs backend

### DIFF
--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -33,7 +33,7 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "dot.bucket", Name: "static/js/app.js"}},
 	}
 	startTime := time.Now()
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		attrs, err := client.Bucket("some-bucket").Attrs(context.Background())
 		if err != nil {
@@ -55,7 +55,7 @@ func TestServerClientBucketAttrs(t *testing.T) {
 func TestServerClientBucketAttrsAfterCreateBucket(t *testing.T) {
 	for _, versioningEnabled := range []bool{true, false} {
 		versioningEnabled := versioningEnabled
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			const bucketName = "best-bucket-ever"
 			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName, VersioningEnabled: versioningEnabled})
 			client := server.Client()
@@ -76,7 +76,7 @@ func TestServerClientBucketAttrsAfterCreateBucket(t *testing.T) {
 func TestServerClientDeleteBucket(t *testing.T) {
 	t.Run("it deletes empty buckets", func(t *testing.T) {
 		const bucketName = "bucket-to-delete"
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
 			client := server.Client()
 			err := client.Bucket(bucketName).Delete(context.Background())
@@ -96,7 +96,7 @@ func TestServerClientDeleteBucket(t *testing.T) {
 	t.Run("it returns an error for non-empty buckets", func(t *testing.T) {
 		const bucketName = "non-empty-bucket"
 		objs := []Object{{ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "static/js/app.js"}}}
-		runServersTest(t, objs, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 			client := server.Client()
 			err := client.Bucket(bucketName).Delete(context.Background())
 			if err == nil {
@@ -107,7 +107,7 @@ func TestServerClientDeleteBucket(t *testing.T) {
 
 	t.Run("it returns an error for unknown buckets", func(t *testing.T) {
 		const bucketName = "non-existent-bucket"
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			client := server.Client()
 			err := client.Bucket(bucketName).Delete(context.Background())
 			if err == nil {
@@ -121,7 +121,7 @@ func TestServerClientBucketAttrsAfterCreateBucketByPost(t *testing.T) {
 	t.Parallel()
 	for _, versioningEnabled := range []bool{true, false} {
 		versioningEnabled := versioningEnabled
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			const bucketName = "post-bucket"
 			client := server.Client()
 			bucket := client.Bucket(bucketName)
@@ -163,7 +163,7 @@ func TestServerClientBucketCreateValidation(t *testing.T) {
 
 	for _, bucketName := range bucketNames {
 		bucketName := bucketName
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			client := server.Client()
 			err := client.Bucket(bucketName).Create(context.Background(), "whatever", nil)
 			if err == nil {
@@ -174,7 +174,7 @@ func TestServerClientBucketCreateValidation(t *testing.T) {
 }
 
 func TestServerClientBucketAttrsNotFound(t *testing.T) {
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		attrs, err := client.Bucket("some-bucket").Attrs(context.Background())
 		if err == nil {
@@ -195,7 +195,7 @@ func TestServerClientListBuckets(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "dot.bucket", Name: "static/js/app.js"}},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		const versionedBucketName = "post-bucket-with-versioning"
 		versionedBucketAttrs := storage.BucketAttrs{

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -185,7 +185,7 @@ func TestServerClientObjectAttrs(t *testing.T) {
 	tests := getObjectTestCases()
 	for _, test := range tests {
 		test := test
-		runServersTest(t, []Object{test.obj}, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{objs: []Object{test.obj}}, func(t *testing.T, server *Server) {
 			t.Run(test.testCase, func(t *testing.T) {
 				client := server.Client()
 				objHandle := client.Bucket(test.obj.BucketName).Object(test.obj.Name)
@@ -203,7 +203,7 @@ func TestServerClientObjectAttrsAfterCreateObject(t *testing.T) {
 	tests := getObjectTestCases()
 	for _, test := range tests {
 		test := test
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			server.CreateObject(test.obj)
 			client := server.Client()
 			objHandle := client.Bucket(test.obj.BucketName).Object(test.obj.Name)
@@ -217,7 +217,7 @@ func TestServerClientObjectAttrsAfterCreateObject(t *testing.T) {
 }
 
 func TestServerClientObjectAttrsAfterOverwriteWithVersioning(t *testing.T) {
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		const (
 			bucketName  = "some-bucket-with-ver"
 			content     = "some nice content"
@@ -289,7 +289,7 @@ func TestServerClientObjectAttrsErrors(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-01.jpg"}},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		tests := []struct {
 			testCase   string
 			bucketName string
@@ -340,7 +340,7 @@ func TestServerClientObjectReader(t *testing.T) {
 		},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		objHandle := client.Bucket(bucketName).Object(objectName)
 		reader, err := objHandle.NewReader(context.TODO())
@@ -379,7 +379,7 @@ func TestServerClientObjectRangeReader(t *testing.T) {
 		},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		tests := []struct {
 			testCase string
 			offset   int64
@@ -439,7 +439,7 @@ func TestServerClientObjectReaderAfterCreateObject(t *testing.T) {
 		contentType = "text/plain; charset=iso-8859"
 	)
 
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		server.CreateObject(Object{
 			ObjectAttrs: ObjectAttrs{
 				BucketName:  bucketName,
@@ -476,7 +476,7 @@ func TestServerClientObjectReaderAgainstSpecificGenerations(t *testing.T) {
 		contentType = "text/plain; charset=iso-8859"
 	)
 
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName, VersioningEnabled: true})
 		object1 := Object{
 			ObjectAttrs: ObjectAttrs{
@@ -531,7 +531,7 @@ func TestServerClientObjectReaderError(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-01.jpg"}},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		tests := []struct {
 			testCase   string
 			bucketName string
@@ -750,7 +750,7 @@ func getTestCasesForListTests(versioningEnabled, withOverwrites bool) []listTest
 }
 
 func TestServiceClientListObjects(t *testing.T) {
-	runServersTest(t, getObjectsForListTests(), func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: getObjectsForListTests()}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket"})
 		tests := getTestCasesForListTests(false, false)
 		client := server.Client()
@@ -788,7 +788,7 @@ func TestServerClientListAfterCreate(t *testing.T) {
 		for _, withOverwrites := range []bool{true, false} {
 			versioningEnabled := versioningEnabled
 			withOverwrites := withOverwrites
-			runServersTest(t, nil, func(t *testing.T, server *Server) {
+			runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 				for _, bucketName := range []string{"some-bucket", "other-bucket", "empty-bucket"} {
 					server.CreateBucketWithOpts(CreateBucketOpts{
 						Name:              bucketName,
@@ -965,7 +965,7 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 	}
 	for _, test := range tests {
 		test := test
-		runServersTest(t, nil, func(t *testing.T, server *Server) {
+		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 			for _, bucketName := range []string{"some-bucket", "other-bucket", "empty-bucket"} {
 				server.CreateBucketWithOpts(CreateBucketOpts{
 					Name:              bucketName,
@@ -1008,7 +1008,7 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 }
 
 func TestServiceClientListObjectsBucketNotFound(t *testing.T) {
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		iter := server.Client().Bucket("some-bucket").Objects(context.TODO(), nil)
 		obj, err := iter.Next()
 		if err == nil {
@@ -1042,7 +1042,7 @@ func TestServiceClientRewriteObject(t *testing.T) {
 		},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket"})
 		tests := []struct {
 			testCase   string
@@ -1197,7 +1197,7 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.testCase, func(t *testing.T) {
-			runServersTest(t, []Object{}, func(t *testing.T, server *Server) {
+			runServersTest(t, runServersOptions{objs: []Object{}}, func(t *testing.T, server *Server) {
 				server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket", VersioningEnabled: false})
 				server.CreateBucketWithOpts(CreateBucketOpts{Name: "first-bucket", VersioningEnabled: test.versioning})
 				for _, obj := range objs {
@@ -1267,7 +1267,7 @@ func TestServerClientObjectDelete(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName}, Content: []byte(content)},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		objHandle := client.Bucket(bucketName).Object(objectName)
 		err := objHandle.Delete(context.TODO())
@@ -1284,7 +1284,7 @@ func TestServerClientObjectDelete(t *testing.T) {
 func TestServerClientObjectDeleteWithVersioning(t *testing.T) {
 	obj := Object{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-01.jpg", Generation: 123}, Content: []byte("some nice content")}
 
-	runServersTest(t, nil, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: obj.BucketName, VersioningEnabled: true})
 		server.CreateObject(obj)
 
@@ -1313,7 +1313,7 @@ func TestServerClientObjectDeleteErrors(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-01.jpg"}},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		tests := []struct {
 			testCase   string
 			bucketName string
@@ -1348,7 +1348,7 @@ func TestServerClientObjectSetAclPrivate(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/public-to-private.jpg"}},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		t.Run("public to private", func(t *testing.T) {
 			ctx := context.Background()
 			objHandle := server.Client().Bucket("some-bucket").Object("img/public-to-private.jpg")
@@ -1399,7 +1399,7 @@ func TestServerClientObjectPatchMetadata(t *testing.T) {
 			Content: []byte(content),
 		},
 	}
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		client := server.Client()
 		objHandle := client.Bucket(bucketName).Object(objectName)
 
@@ -1561,7 +1561,7 @@ func TestServiceClientComposeObject(t *testing.T) {
 		},
 	}
 
-	runServersTest(t, objs, func(t *testing.T, server *Server) {
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket"})
 		tests := []struct {
 			testCase          string

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -160,15 +160,15 @@ func (s *Server) checkUploadPreconditions(r *http.Request, bucketName string, ob
 				errorMessage: err.Error(),
 			}
 		}
-		_, err = s.backend.GetObjectWithGeneration(bucketName, objectName, gen)
 		if gen == 0 {
+			_, err := s.backend.GetObject(bucketName, objectName)
 			if err == nil {
 				return &jsonResponse{
 					status:       http.StatusPreconditionFailed,
 					errorMessage: "Precondition failed",
 				}
 			}
-		} else if err != nil {
+		} else if _, err := s.backend.GetObjectWithGeneration(bucketName, objectName, gen); err != nil {
 			return &jsonResponse{
 				status:       http.StatusPreconditionFailed,
 				errorMessage: "Precondition failed",


### PR DESCRIPTION
This change is a follow-up to #735: previously, ifGenerationMatch=0 was
special-cased and the server used GetObject, which works on filesystem
and memory backends. That pull request changed the code to use
GetObjectWithGeneration, which is not supported by the filesystem
backend.

We couldn't catch this in tests because the test suite only runs with
the memory backend, so as part of this change I'm also including the
ability to use the filesystem storage in the test suite. That can get
slow though.

This is a hack and should be revisited once we implement #744.