### PR TITLE
Add HEAD support for storage API object endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ It is possible to use fake-gcs-server with signed URLs, although with a few cave
 - You need to configure fake-gcs-server to accept this local URL (by setting
   `-public-host`)
 
+### Available server flags
+
+fake-gcs-server supports various features that can be configured through flags
+upon start. Use the `-help` flag to list all of them alongside their usage
+instructions
+
+```shell
+docker run --rm fsouza/fake-gcs-server -help
+```
+
 ## Client library examples
 
 For examples using SDK from multiple languages, check out the

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -481,7 +481,7 @@ func (s *Server) listObjects(r *http.Request) jsonResponse {
 }
 
 func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
-	if alt := r.URL.Query().Get("alt"); alt == "media" {
+	if alt := r.URL.Query().Get("alt"); alt == "media" || r.Method == http.MethodHead {
 		s.downloadObject(w, r)
 		return
 	}

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -232,7 +232,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods(http.MethodGet).HandlerFunc(jsonToHTTPHandler(s.listObjectACL))
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.setObjectACL))
 		r.Path("/b/{bucketName}/o/{objectName:.+}/acl/{entity}").Methods(http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.setObjectACL))
-		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods(http.MethodGet).HandlerFunc(s.getObject)
+		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods(http.MethodGet, http.MethodHead).HandlerFunc(s.getObject)
 		r.Path("/b/{bucketName}/o/{objectName:.+}").Methods(http.MethodDelete).HandlerFunc(jsonToHTTPHandler(s.deleteObject))
 		r.Path("/b/{sourceBucket}/o/{sourceObject:.+}/copyTo/b/{destinationBucket}/o/{destinationObject:.+}").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.rewriteObject))
 		r.Path("/b/{sourceBucket}/o/{sourceObject:.+}/rewriteTo/b/{destinationBucket}/o/{destinationObject:.+}").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.rewriteObject))

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -292,6 +292,13 @@ func testDownloadObject(t *testing.T, server *Server) {
 			"something",
 		},
 		{
+			"HEAD: using storage api",
+			http.MethodHead,
+			"://storage.googleapis.com/storage/v1/b/some-bucket/o/files/txt/text-01.txt",
+			map[string]string{"accept-ranges": "bytes", "content-length": "9"},
+			"",
+		},
+		{
 			"HEAD: bucket in the path",
 			http.MethodHead,
 			"://storage.googleapis.com/some-bucket/files/txt/text-01.txt",


### PR DESCRIPTION
I _think_ I found a easy way to fix #667. 

I also took the liberty to update the documentation, spelling out the `-help` flag usage for new users. Fun story, when I started using this emulator, I jumped into the code to figure out if there was a way to support my use case; I went from the endpoints to the handler implementation. Lastly, I found out all that the flags definitions were sitting in `config.go` file, also that I could simply have used said flag all the time :sweat_smile:.

Both changes are in separted commits in case we want to drop or modify any of them.