### PR TITLE
Fix comment to match routing

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -91,7 +91,7 @@ type Options struct {
 	// An example is "storage.gcs.127.0.0.1.nip.io:4443", which will configure
 	// the server to serve objects at:
 	// https://storage.gcs.127.0.0.1.nip.io:4443/<bucket>/<object>
-	// https://<bucket>.storage.gcs.127.0.0.1.nip.io:4443>/<bucket>/<object>
+	// https://<bucket>.storage.gcs.127.0.0.1.nip.io:4443>/<object>
 	// If unset, the default is "storage.googleapis.com", the XML API
 	PublicHost string
 


### PR DESCRIPTION
I think this comment will now better reflect [this routing](https://github.com/fsouza/fake-gcs-server/blob/main/fakestorage/server.go#L266):
```
s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods(http.MethodGet, http.MethodHead).HandlerFunc(s.downloadObject)
s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods(http.MethodPost, http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.insertObject))
```