### PR TITLE
examples/cpp: update deps and pin alpine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
             docker-image: openjdk:11
             entrypoint: /bin/sh
           - lang: cpp
-            docker-image: alpine
+            docker-image: alpine:3.15.4
             entrypoint: /bin/sh
 
     name: test-${{ matrix.lang }}-example

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -15,14 +15,14 @@ set(CRC32C_BUILD_BENCHMARKS OFF CACHE INTERNAL crc32-benchmarks-off)
 set(CRC32C_INSTALL ON CACHE INTERNAL crc32-install-on)
 FetchContent_Declare(
         crc32c
-        URL     https://github.com/google/crc32c/archive/refs/tags/1.1.1.tar.gz
-        URL_HASH SHA256=a6533f45b1670b5d59b38a514d82b09c6fb70cc1050467220216335e873074e8
+        URL     https://github.com/google/crc32c/archive/refs/tags/1.1.2.tar.gz
+        URL_HASH SHA256=ac07840513072b7fcebda6e821068aa04889018f24e10e46181068fb214d7e56
 )
 FetchContent_MakeAvailable(crc32c)
 add_library(Crc32c::crc32c ALIAS crc32c)
 FetchContent_Declare(google-cloud-cpp
-        URL                 https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v1.37.0.tar.gz
-        URL_HASH            SHA256=a7269b21d5e95bebff7833ebb602bcd5bcc79e82a59449cc5d5b350ff2f50bbc)
+        URL                 https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v1.40.2.tar.gz
+        URL_HASH            SHA256=394595d8ce0f17ad9f1a1e3efa1c54118a1246df617a7388da7111dfb299b05b)
 FetchContent_MakeAvailable(google-cloud-cpp)
 
 add_executable(cpp-example cpp-examples.cpp)


### PR DESCRIPTION
Looks like the alpine upgrade brings a new version of abseil. I'll investigate this later or remove the cpp example.