### PR TITLE
backend/fs: set object Generation when creating the object

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -79,10 +79,7 @@ func uploadAndCompare(t *testing.T, storage Storage, obj Object) int64 {
 	noError(t, err)
 	activeObj, err := storage.GetObject(obj.BucketName, obj.Name)
 	noError(t, err)
-	if isFSStorage && activeObj.Generation != 0 {
-		t.Errorf("FS should leave generation empty, as it does not persist it. Value: %d", activeObj.Generation)
-	}
-	if !isFSStorage && activeObj.Generation == 0 {
+	if activeObj.Generation == 0 {
 		t.Errorf("generation is empty, but we expect a unique int")
 	}
 	if err := compareObjects(activeObj, obj); err != nil {

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -140,6 +140,12 @@ func (s *storageFS) CreateObject(obj Object) (Object, error) {
 	if obj.Generation > 0 {
 		return Object{}, errors.New("not implemented: fs storage type does not support objects generation yet")
 	}
+
+	// Note: this was a quick fix for issue #701. Now that we have a way to
+	// persist object attributes, we should implement versioning in the
+	// filesystem backend and handle generations outside of the backends.
+	obj.Generation = time.Now().UnixNano() / 1000
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	err := s.createBucket(obj.BucketName)
@@ -275,6 +281,7 @@ func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[str
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
+	obj.Generation = 0
 	s.CreateObject(obj) // recreate object
 	return obj, nil
 }


### PR DESCRIPTION
Also update it accordingly.

Fixes #701.