### PR TITLE
backend/fs: partial support for GetObjectWithGeneration

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -86,14 +86,9 @@ func uploadAndCompare(t *testing.T, storage Storage, obj Object) int64 {
 		t.Errorf("object retrieved differs from the created one. Descr: %v", err)
 	}
 	objFromGeneration, err := storage.GetObjectWithGeneration(obj.BucketName, obj.Name, activeObj.Generation)
-	if isFSStorage {
-		t.Log("FS should not implement fetch with generation")
-		shouldError(t, err)
-	} else {
-		noError(t, err)
-		if err := compareObjects(objFromGeneration, obj); err != nil {
-			t.Errorf("object retrieved differs from the created one. Descr: %v", err)
-		}
+	noError(t, err)
+	if err := compareObjects(objFromGeneration, obj); err != nil {
+		t.Errorf("object retrieved differs from the created one. Descr: %v", err)
 	}
 	return activeObj.Generation
 }

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -214,7 +214,14 @@ func (s *storageFS) GetObject(bucketName, objectName string) (Object, error) {
 // GetObjectWithGeneration retrieves an specific version of the object. Not
 // implemented for this backend.
 func (s *storageFS) GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error) {
-	return Object{}, errors.New("not implemented: fs storage type does not support versioning yet")
+	obj, err := s.GetObject(bucketName, objectName)
+	if err != nil {
+		return obj, err
+	}
+	if obj.Generation != generation {
+		return obj, fmt.Errorf("generation mismatch, object generation is %v, requested generation is %v (note: filesystem backend does not support versioning)", obj.Generation, generation)
+	}
+	return obj, nil
 }
 
 func (s *storageFS) getObject(bucketName, objectName string) (Object, error) {


### PR DESCRIPTION
Generations without versioning.

This is an alternative fix for #816 that doesn't require reverting the
fix for #701.