### PR TITLE
return attrs for newly created object in rewrite

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -624,12 +624,12 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 		Content: append([]byte(nil), obj.Content...),
 	}
 
-	_, err = s.createObject(newObject)
+	created, err := s.createObject(newObject)
 	if err != nil {
 		return errToJsonResponse(err)
 	}
 
-	return jsonResponse{data: newObjectRewriteResponse(newObject.ObjectAttrs)}
+	return jsonResponse{data: newObjectRewriteResponse(created.ObjectAttrs)}
 }
 
 func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1247,7 +1247,6 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 				copier := dstObject.CopierFrom(sourceObject)
 				copier.ContentType = contentType
 				attrs, err := copier.Run(context.TODO())
-
 				if err != nil {
 					if test.expectErr {
 						t.Skip("we were expecting an error for this test")

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1136,6 +1136,9 @@ func TestServiceClientRewriteObject(t *testing.T) {
 				if !bytes.Equal(attrs.MD5, hash) {
 					t.Errorf("wrong hash returned\nwant %d\ngot   %d", hash, attrs.MD5)
 				}
+				if attrs.Generation == 0 {
+					t.Errorf("Generation was zero, expected non-zero")
+				}
 				obj, err := server.GetObject(test.bucketName, test.objectName)
 				if err != nil {
 					t.Fatal(err)
@@ -1244,6 +1247,7 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 				copier := dstObject.CopierFrom(sourceObject)
 				copier.ContentType = contentType
 				attrs, err := copier.Run(context.TODO())
+
 				if err != nil {
 					if test.expectErr {
 						t.Skip("we were expecting an error for this test")
@@ -1267,6 +1271,9 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 				}
 				if !bytes.Equal(attrs.MD5, expectedHash) {
 					t.Errorf("wrong hash returned\nwant %d\ngot   %d", expectedHash, attrs.MD5)
+				}
+				if attrs.Generation == 0 {
+					t.Errorf("Generation was zero, expected non-zero")
 				}
 				obj, err := server.GetObject(test.bucketName, test.objectName)
 				if err != nil {


### PR DESCRIPTION
When using [Copier.Run](https://pkg.go.dev/cloud.google.com/go/storage#Copier.Run) to copy a file the resulting attributes object had 0 for generation.  This change seems to populate the generation field with the value from the created object, but I'm not certain it's actually the correct fix--maybe the other attributes should be from newObject?

Please let me know if you need more information about the issue or the change. The tests appear to be passing. 