### PR TITLE
Fix upload response structure

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -238,7 +238,7 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 	if err != nil {
 		return errToJsonResponse(err)
 	}
-	return jsonResponse{data: obj}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
 func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
@@ -283,7 +283,7 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 	if err != nil {
 		return errToJsonResponse(err)
 	}
-	return jsonResponse{data: obj}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
 func getObjectACL(predefinedACL string) []storage.ACLRule {
@@ -365,7 +365,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 	if err != nil {
 		return errToJsonResponse(err)
 	}
-	return jsonResponse{data: obj}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
 func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonResponse {
@@ -404,7 +404,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 		header.Set("X-Goog-Upload-Status", "active")
 	}
 	return jsonResponse{
-		data:   obj,
+		data:   newObjectResponse(obj.ObjectAttrs),
 		header: header,
 	}
 }
@@ -499,7 +499,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	}
 	return jsonResponse{
 		status: status,
-		data:   obj,
+		data:   newObjectResponse(obj.ObjectAttrs),
 		header: responseHeader,
 	}
 }


### PR DESCRIPTION
The API response returned for the Upload Endpoints by the fake-gcs-server differs from the response documented in Google for the `insert` endpoint. 

Reference: https://cloud.google.com/storage/docs/json_api/v1/objects/insert#response