### PR TITLE
Add support for gzip transcoding

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -383,10 +383,14 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if objName == "" {
 		objName = metadata.Name
 	}
+	if contentEncoding == "" {
+		contentEncoding = metadata.ContentEncoding
+	}
 	obj := Object{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:      bucketName,
 			Name:            objName,
+			ContentType:     metadata.ContentType,
 			ContentEncoding: contentEncoding,
 			ACL:             getObjectACL(predefinedACL),
 			Metadata:        metadata.Metadata,


### PR DESCRIPTION
When an object has Content-Encoding: gzip, and an object download request does not have Accept-Encoding: gzip, GCS will decompress the object before serving it. This is documented here: https://cloud.google.com/storage/docs/transcoding

I've added support for this alongside the current range request logic (it's related - if we are transcoding, we ignore the range header).

To make this work for our use-case I also had to fix a bug in resumable uploads where content encoding metadata was not being set if it was specified in the request body.

EDIT: I just noticed https://github.com/fsouza/fake-gcs-server/issues/532, I believe this PR fixes that as well.