### PR TITLE
Allow GET/HEAD on signed URLs

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -263,6 +263,7 @@ func (s *Server) buildMuxer() {
 
 	// Signed URL Uploads
 	s.mux.MatcherFunc(s.publicHostMatcher).Path("/{bucketName}/{objectName:.+}").Methods(http.MethodPost, http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.insertObject))
+	s.mux.MatcherFunc(s.publicHostMatcher).Path("/{bucketName}/{objectName:.+}").Methods(http.MethodGet, http.MethodHead).HandlerFunc(s.getObject)
 	s.mux.Host(bucketHost).Path("/{objectName:.+}").Methods(http.MethodPost, http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.insertObject))
 	s.mux.Host("{bucketName:.+}").Path("/{objectName:.+}").Methods(http.MethodPost, http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.insertObject))
 }


### PR DESCRIPTION
This allows downloading from signed URLs.

As with uploads, there is no signature verification etc.