### PR TITLE
Streaming downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 fake-gcs-server
+.idea

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -272,11 +272,11 @@ func (o *objectAttrsList) Swap(i int, j int) {
 	d[i], d[j] = d[j], d[i]
 }
 
-// CreateObjectForTests stores the given object internally.
+// CreateObject stores the given object internally.
 //
 // If the bucket within the object doesn't exist, it also creates it. If the
 // object already exists, it overrides the object.
-func (s *Server) CreateObjectForTests(obj StreamingObject) {
+func (s *Server) CreateObject(obj StreamingObject) {
 	obj, err := s.createObject(obj)
 	if err != nil {
 		panic(err)

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -205,7 +205,7 @@ func TestServerClientObjectAttrsAfterCreateObject(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
-			server.CreateObjectForTests(test.obj.StreamingObject())
+			server.CreateObject(test.obj.StreamingObject())
 			client := server.Client()
 			objHandle := client.Bucket(test.obj.BucketName).Object(test.obj.Name)
 			attrs, err := objHandle.Attrs(context.TODO())
@@ -231,7 +231,7 @@ func TestServerClientObjectAttrsAfterOverwriteWithVersioning(t *testing.T) {
 			Content:     []byte(content),
 			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "img/low-res/party-01.jpg", ContentType: contentType, Crc32c: checksum.EncodedChecksum(uint32ToBytes(uint32Checksum([]byte(content)))), Md5Hash: checksum.EncodedHash(checksum.MD5Hash([]byte(content))), Metadata: map[string]string{"MetaHeader": metaValue}},
 		}
-		server.CreateObjectForTests(initialObj.StreamingObject())
+		server.CreateObject(initialObj.StreamingObject())
 		client := server.Client()
 		objHandle := client.Bucket(bucketName).Object(initialObj.Name)
 		originalObjAttrs, err := objHandle.Attrs(context.TODO())
@@ -248,7 +248,7 @@ func TestServerClientObjectAttrsAfterOverwriteWithVersioning(t *testing.T) {
 			Content:     []byte(content2),
 			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "img/low-res/party-01.jpg", ContentType: contentType, Crc32c: checksum.EncodedChecksum(uint32ToBytes(uint32Checksum([]byte(content2)))), Md5Hash: checksum.EncodedHash(checksum.MD5Hash([]byte(content2)))},
 		}
-		server.CreateObjectForTests(latestObjVersion.StreamingObject())
+		server.CreateObject(latestObjVersion.StreamingObject())
 		objHandle = client.Bucket(bucketName).Object(latestObjVersion.Name)
 		latestAttrs, err := objHandle.Attrs(context.TODO())
 		if err != nil {
@@ -481,7 +481,7 @@ func TestServerClientObjectReaderAfterCreateObject(t *testing.T) {
 			},
 			Content: []byte(content),
 		}
-		server.CreateObjectForTests(obj.StreamingObject())
+		server.CreateObject(obj.StreamingObject())
 		client := server.Client()
 		objHandle := client.Bucket(bucketName).Object(objectName)
 		reader, err := objHandle.NewReader(context.TODO())
@@ -521,7 +521,7 @@ func TestServerClientObjectReaderAgainstSpecificGenerations(t *testing.T) {
 			},
 			Content: []byte(content),
 		}
-		server.CreateObjectForTests(object1.StreamingObject())
+		server.CreateObject(object1.StreamingObject())
 		object2 := Object{
 			ObjectAttrs: ObjectAttrs{
 				BucketName:  bucketName,
@@ -530,7 +530,7 @@ func TestServerClientObjectReaderAgainstSpecificGenerations(t *testing.T) {
 			},
 			Content: []byte(content + "2"),
 		}
-		server.CreateObjectForTests(object2.StreamingObject())
+		server.CreateObject(object2.StreamingObject())
 		client := server.Client()
 		latestHandle := client.Bucket(bucketName).Object(objectName)
 		latestAttrs, err := latestHandle.Attrs(context.TODO())
@@ -830,10 +830,10 @@ func TestServerClientListAfterCreate(t *testing.T) {
 					})
 				}
 				for _, obj := range getObjectsForListTests() {
-					server.CreateObjectForTests(obj.StreamingObject())
+					server.CreateObject(obj.StreamingObject())
 					if withOverwrites {
 						obj.Content = []byte("final content")
-						server.CreateObjectForTests(obj.StreamingObject())
+						server.CreateObject(obj.StreamingObject())
 					}
 				}
 				tests := getTestCasesForListTests(versioningEnabled, withOverwrites)
@@ -1008,11 +1008,11 @@ func TestServerClientListAfterCreateQueryingAllVersions(t *testing.T) {
 			}
 			for _, obj := range getObjectsForListTests() {
 				obj.Generation = initialGeneration
-				server.CreateObjectForTests(obj.StreamingObject())
+				server.CreateObject(obj.StreamingObject())
 				if test.withOverwrites {
 					obj.Generation = finalGeneration
 					obj.Content = []byte("final content")
-					server.CreateObjectForTests(obj.StreamingObject())
+					server.CreateObject(obj.StreamingObject())
 				}
 			}
 			client := server.Client()
@@ -1242,7 +1242,7 @@ func TestServiceClientRewriteObjectWithGenerations(t *testing.T) {
 				server.CreateBucketWithOpts(CreateBucketOpts{Name: "empty-bucket", VersioningEnabled: false})
 				server.CreateBucketWithOpts(CreateBucketOpts{Name: "first-bucket", VersioningEnabled: test.versioning})
 				for _, obj := range objs {
-					server.CreateObjectForTests(obj.StreamingObject())
+					server.CreateObject(obj.StreamingObject())
 				}
 				client := server.Client()
 				sourceObject := client.Bucket("first-bucket").Object("files/some-file.txt").Generation(overwrittenGeneration)
@@ -1334,7 +1334,7 @@ func TestServerClientObjectDeleteWithVersioning(t *testing.T) {
 
 	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		server.CreateBucketWithOpts(CreateBucketOpts{Name: obj.BucketName, VersioningEnabled: true})
-		server.CreateObjectForTests(obj.StreamingObject())
+		server.CreateObject(obj.StreamingObject())
 
 		client := server.Client()
 		objHandle := client.Bucket(obj.BucketName).Object(obj.Name)

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -183,13 +183,13 @@ func NewServerWithOptions(options Options) (*Server, error) {
 }
 
 func newServer(options Options) (*Server, error) {
-	backendObjects := toBackendObjects(options.InitialObjects)
+	backendObjects := bufferedObjectsToBackendObjects(options.InitialObjects)
 	var backendStorage backend.Storage
 	var err error
 	if options.StorageRoot != "" {
 		backendStorage, err = backend.NewStorageFS(backendObjects, options.StorageRoot)
 	} else {
-		backendStorage = backend.NewStorageMemory(backendObjects)
+		backendStorage, err = backend.NewStorageMemory(backendObjects)
 	}
 	if err != nil {
 		return nil, err

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -895,7 +895,6 @@ func TestServerBatchRequest(t *testing.T) {
 type fakeEventFields struct {
 	BucketName string
 	Name       string
-	Content    []byte
 	Metadata   map[string]string
 }
 
@@ -903,7 +902,6 @@ func fakeEventFieldsFromObject(obj Object) fakeEventFields {
 	return fakeEventFields{
 		BucketName: obj.BucketName,
 		Name:       obj.Name,
-		Content:    obj.Content,
 		Metadata:   obj.Metadata,
 	}
 }
@@ -923,9 +921,14 @@ type fakeEventManager struct {
 	events []fakeEvent
 }
 
-func (m *fakeEventManager) Trigger(o *backend.Object, eventType notification.EventType, extraEventAttr map[string]string) {
+func (m *fakeEventManager) Trigger(o *backend.StreamingObject, eventType notification.EventType, extraEventAttr map[string]string) {
+	streamingObject := fromBackendObjects([]backend.StreamingObject{*o})[0]
+	bufferedObject, err := streamingObject.BufferedObject()
+	if err != nil {
+		panic(err)
+	}
 	m.events = append(m.events, fakeEvent{
-		obj:       fakeEventFieldsFromObject(fromBackendObjects([]backend.Object{*o})[0]),
+		obj:       fakeEventFieldsFromObject(bufferedObject),
 		eventType: eventType,
 	})
 }

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -404,7 +404,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 
 // uploadFileContent accepts a chunk of a resumable upload
 //
-// A resumeable upload is sent in one or more chunks. The request's
+// A resumable upload is sent in one or more chunks. The request's
 // "Content-Range" header is used to determine if more data is expected.
 //
 // When sending streaming content, the total size is unknown until the stream

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -5,8 +5,10 @@
 package fakestorage
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -122,26 +124,19 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 	if err != nil {
 		return xmlResponse{errorMessage: err.Error()}
 	}
-	data, err := io.ReadAll(infile)
-	if err != nil {
-		return xmlResponse{errorMessage: err.Error()}
-	}
-	md5Hash := checksum.EncodedMd5Hash(data)
-	obj := Object{
+	obj := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:      bucketName,
 			Name:            name,
 			ContentType:     contentType,
 			ContentEncoding: contentEncoding,
-			Crc32c:          checksum.EncodedCrc32cChecksum(data),
-			Md5Hash:         md5Hash,
-			Etag:            fmt.Sprintf("%q", md5Hash),
 			ACL:             getObjectACL(predefinedACL),
 			Metadata:        metaData,
 		},
-		Content: data,
+		Content: infile,
 	}
-	_, err = s.createObject(obj)
+	obj, err = s.createObject(obj)
+	defer obj.Close()
 	if err != nil {
 		return xmlResponse{errorMessage: err.Error()}
 	}
@@ -186,7 +181,8 @@ func (s *Server) checkUploadPreconditions(r *http.Request, bucketName string, ob
 				errorMessage: err.Error(),
 			}
 		}
-		_, err = s.backend.GetObjectWithGeneration(bucketName, objectName, gen)
+		obj, err := s.backend.GetObjectWithGeneration(bucketName, objectName, gen)
+		defer obj.Close()
 		if gen == 0 {
 			if err != nil {
 				return &jsonResponse{
@@ -216,29 +212,30 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 			errorMessage: "name is required for simple uploads",
 		}
 	}
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
-		return jsonResponse{errorMessage: err.Error()}
-	}
-	md5Hash := checksum.EncodedMd5Hash(data)
-	obj := Object{
+	obj := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:      bucketName,
 			Name:            name,
 			ContentType:     r.Header.Get(contentTypeHeader),
 			ContentEncoding: contentEncoding,
-			Crc32c:          checksum.EncodedCrc32cChecksum(data),
-			Md5Hash:         md5Hash,
-			Etag:            fmt.Sprintf("%q", md5Hash),
 			ACL:             getObjectACL(predefinedACL),
 		},
-		Content: data,
+		Content: notImplementedSeeker{r.Body},
 	}
-	obj, err = s.createObject(obj)
+	obj, err := s.createObject(obj)
+	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
 	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
+}
+
+type notImplementedSeeker struct {
+	io.ReadCloser
+}
+
+func (s notImplementedSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("not implemented")
 }
 
 func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
@@ -260,26 +257,19 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 		}
 	}
 
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
-		return jsonResponse{errorMessage: err.Error()}
-	}
-	md5Hash := checksum.EncodedMd5Hash(data)
-	obj := Object{
+	obj := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:      bucketName,
 			Name:            name,
 			ContentType:     r.Header.Get(contentTypeHeader),
 			ContentEncoding: contentEncoding,
-			Crc32c:          checksum.EncodedCrc32cChecksum(data),
-			Md5Hash:         md5Hash,
-			Etag:            fmt.Sprintf("%q", md5Hash),
 			ACL:             getObjectACL(predefinedACL),
 			Metadata:        metaData,
 		},
-		Content: data,
+		Content: notImplementedSeeker{r.Body},
 	}
-	obj, err = s.createObject(obj)
+	obj, err := s.createObject(obj)
+	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
@@ -319,6 +309,9 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 	)
 	var contentType string
 	reader := multipart.NewReader(r.Body, params["boundary"])
+
+	var partReaders []io.Reader
+
 	part, err := reader.NextPart()
 	for ; err == nil; part, err = reader.NextPart() {
 		if metadata == nil {
@@ -327,6 +320,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		} else {
 			contentType = part.Header.Get(contentTypeHeader)
 			content, err = loadContent(part)
+			partReaders = append(partReaders, bytes.NewReader(content))
 		}
 		if err != nil {
 			break
@@ -346,22 +340,19 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		return *resp
 	}
 
-	md5Hash := checksum.EncodedMd5Hash(content)
-	obj := Object{
+	obj := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:      bucketName,
 			Name:            objName,
 			ContentType:     contentType,
 			ContentEncoding: metadata.ContentEncoding,
-			Crc32c:          checksum.EncodedCrc32cChecksum(content),
-			Md5Hash:         md5Hash,
-			Etag:            fmt.Sprintf("%q", md5Hash),
 			ACL:             getObjectACL(predefinedACL),
 			Metadata:        metadata.Metadata,
 		},
-		Content: content,
+		Content: notImplementedSeeker{io.NopCloser(io.MultiReader(partReaders...))},
 	}
 	obj, err = s.createObject(obj)
+	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
@@ -411,7 +402,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 
 // uploadFileContent accepts a chunk of a resumable upload
 //
-// A resumable upload is sent in one or more chunks. The request's
+// A resumeable upload is sent in one or more chunks. The request's
 // "Content-Range" header is used to determine if more data is expected.
 //
 // When sending streaming content, the total size is unknown until the stream
@@ -451,6 +442,8 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 		return jsonResponse{status: http.StatusNotFound}
 	}
 	obj := rawObj.(Object)
+	// TODO: stream upload file content to and from disk (when using the FS
+	// backend, at least) instead of loading the entire content into memory.
 	content, err := loadContent(r.Body)
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
@@ -480,7 +473,12 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	}
 	if commit {
 		s.uploads.Delete(uploadID)
-		obj, err = s.createObject(obj)
+		streamingObject, err := s.createObject(obj.StreamingObject())
+		defer streamingObject.Close()
+		if err != nil {
+			return errToJsonResponse(err)
+		}
+		obj, err = streamingObject.BufferedObject()
 		if err != nil {
 			return errToJsonResponse(err)
 		}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -136,10 +136,10 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 		Content: infile,
 	}
 	obj, err = s.createObject(obj)
-	defer obj.Close()
 	if err != nil {
 		return xmlResponse{errorMessage: err.Error()}
 	}
+	defer obj.Close()
 	return xmlResponse{status: http.StatusNoContent}
 }
 
@@ -182,7 +182,9 @@ func (s *Server) checkUploadPreconditions(r *http.Request, bucketName string, ob
 			}
 		}
 		obj, err := s.backend.GetObjectWithGeneration(bucketName, objectName, gen)
-		defer obj.Close()
+		// Calling Close before checking err is okay on objects, and the return
+		// path below is complicated.
+		defer obj.Close() //lint:ignore SA5001 // see above
 		if gen == 0 {
 			if err != nil {
 				return &jsonResponse{
@@ -223,10 +225,10 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 		Content: notImplementedSeeker{r.Body},
 	}
 	obj, err := s.createObject(obj)
-	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
+	obj.Close()
 	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
@@ -269,10 +271,10 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 		Content: notImplementedSeeker{r.Body},
 	}
 	obj, err := s.createObject(obj)
-	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
+	obj.Close()
 	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
@@ -352,10 +354,10 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		Content: notImplementedSeeker{io.NopCloser(io.MultiReader(partReaders...))},
 	}
 	obj, err = s.createObject(obj)
-	defer obj.Close()
 	if err != nil {
 		return errToJsonResponse(err)
 	}
+	obj.Close()
 	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
 }
 
@@ -474,10 +476,10 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	if commit {
 		s.uploads.Delete(uploadID)
 		streamingObject, err := s.createObject(obj.StreamingObject())
-		defer streamingObject.Close()
 		if err != nil {
 			return errToJsonResponse(err)
 		}
+		defer streamingObject.Close()
 		obj, err = streamingObject.BufferedObject()
 		if err != nil {
 			return errToJsonResponse(err)

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -145,7 +145,7 @@ func TestServerClientObjectWriterOverwrite(t *testing.T) {
 			},
 			Content: []byte("some content"),
 		}
-		server.CreateObjectForTests(obj.StreamingObject())
+		server.CreateObject(obj.StreamingObject())
 		objHandle := server.Client().Bucket("some-bucket").Object("some-object.txt")
 		w := objHandle.NewWriter(context.Background())
 		w.ContentType = contentType

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -70,7 +70,11 @@ func TestServerClientObjectWriter(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				obj, err := server.GetObject(test.bucketName, test.objectName)
+				streamingObject, err := server.GetObject(test.bucketName, test.objectName)
+				if err != nil {
+					t.Fatal(err)
+				}
+				obj, err := streamingObject.BufferedObject()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -133,14 +137,15 @@ func TestServerClientObjectWriterOverwrite(t *testing.T) {
 	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		const content = "other content"
 		const contentType = "text/plain"
-		server.CreateObject(Object{
+		obj := Object{
 			ObjectAttrs: ObjectAttrs{
 				BucketName:  "some-bucket",
 				Name:        "some-object.txt",
 				ContentType: "some-stff",
 			},
 			Content: []byte("some content"),
-		})
+		}
+		server.CreateObjectForTests(obj.StreamingObject())
 		objHandle := server.Client().Bucket("some-bucket").Object("some-object.txt")
 		w := objHandle.NewWriter(context.Background())
 		w.ContentType = contentType
@@ -149,7 +154,11 @@ func TestServerClientObjectWriterOverwrite(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		obj, err := server.GetObject("some-bucket", "some-object.txt")
+		streamingObject, err := server.GetObject("some-bucket", "some-object.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		obj, err = streamingObject.BufferedObject()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -417,7 +426,11 @@ func TestServerClientSimpleUpload(t *testing.T) {
 		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
 	}
 
-	obj, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	streamingObject, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := streamingObject.BufferedObject()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +474,11 @@ func TestServerClientSignedUpload(t *testing.T) {
 		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
 	}
 
-	obj, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	streamingObject, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := streamingObject.BufferedObject()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -552,7 +569,11 @@ func TestServerClientUploadWithPredefinedAclPublicRead(t *testing.T) {
 		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
 	}
 
-	obj, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	streamingObject, err := server.GetObject("other-bucket", "some/nice/object.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := streamingObject.BufferedObject()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -809,7 +830,11 @@ func TestServerGzippedUpload(t *testing.T) {
 				t.Errorf("expected a 200 response, got: %d", resp.StatusCode)
 			}
 
-			obj, err := server.GetObject(bucketName, "testobj")
+			streamingObject, err := server.GetObject(bucketName, "testobj")
+			if err != nil {
+				t.Fatal(err)
+			}
+			obj, err := streamingObject.BufferedObject()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -889,7 +914,11 @@ func TestFormDataUpload(t *testing.T) {
 		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
 	}
 
-	obj, err := server.GetObject("other-bucket", "object.txt")
+	streamingObject, err := server.GetObject("other-bucket", "object.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := streamingObject.BufferedObject()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	cloud.google.com/go v0.102.1 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
+	github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 h1:iW0a5ljuFxkLGPNem5Ui+KBjFJzKg4Fv2fnxe4dvzpM=
+github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5/go.mod h1:Y2QMoi1vgtOIfc+6DhrMOGkLoGzqSV2rKp4Sm+opsyA=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -305,31 +305,6 @@ func TestBucketDuplication(t *testing.T) {
 	})
 }
 
-func compareObjects(o1, o2 Object) error {
-	if o1.BucketName != o2.BucketName {
-		return fmt.Errorf("bucket name differs:\nmain %q\narg  %q", o1.BucketName, o2.BucketName)
-	}
-	if o1.Name != o2.Name {
-		return fmt.Errorf("wrong object name:\nmain %q\narg  %q", o1.Name, o2.Name)
-	}
-	if o1.ContentType != o2.ContentType {
-		return fmt.Errorf("wrong object contenttype:\nmain %q\narg  %q", o1.ContentType, o2.ContentType)
-	}
-	if o1.Crc32c != o2.Crc32c {
-		return fmt.Errorf("wrong crc:\nmain %q\narg  %q", o1.Crc32c, o2.Crc32c)
-	}
-	if o1.Md5Hash != o2.Md5Hash {
-		return fmt.Errorf("wrong md5:\nmain %q\narg  %q", o1.Md5Hash, o2.Md5Hash)
-	}
-	if o1.Generation != 0 && o2.Generation != 0 && o1.Generation != o2.Generation {
-		return fmt.Errorf("generations different from 0, but not equal:\nmain %q\narg  %q", o1.Generation, o2.Generation)
-	}
-	if !bytes.Equal(o1.Content, o2.Content) {
-		return fmt.Errorf("wrong object content:\nmain %q\narg  %q", o1.Content, o2.Content)
-	}
-	return nil
-}
-
 func compareStreamingObjects(o1, o2 StreamingObject) error {
 	if o1.BucketName != o2.BucketName {
 		return fmt.Errorf("bucket name differs:\nmain %q\narg  %q", o1.BucketName, o2.BucketName)

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -200,7 +200,7 @@ func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 		return StreamingObject{}, err
 	}
 
-	err = os.Rename(tempFile.Name(), path)
+	err = compatRename(tempFile.Name(), path)
 	if err != nil {
 		return StreamingObject{}, err
 	}
@@ -288,7 +288,7 @@ func (s *storageFS) getObject(bucketName, objectName string) (StreamingObject, e
 
 func openObjectAndSetSize(obj *StreamingObject, path string) error {
 	// file is expected to be closed by the caller by calling obj.Close()
-	file, err := os.Open(path)
+	file, err := compatOpenAllowingRename(path)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -174,6 +174,7 @@ func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 	if err != nil {
 		return StreamingObject{}, err
 	}
+	defer tempFile.Close()
 
 	// The file is renamed below, which causes this to be a no-op. If the
 	// function returns before the rename, though, the temp file will be

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -240,6 +240,7 @@ func (s *storageFS) ListObjects(bucketName string, prefix string, versions bool)
 		if err != nil {
 			return nil, err
 		}
+		object.Close()
 		objects = append(objects, object.ObjectAttrs)
 	}
 	return objects, nil

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -60,10 +60,11 @@ func NewStorageFS(objects []StreamingObject, rootDir string) (Storage, error) {
 
 	s := &storageFS{rootDir: rootDir}
 	for _, o := range objects {
-		_, err := s.CreateObject(o)
+		obj, err := s.CreateObject(o)
 		if err != nil {
 			return nil, err
 		}
+		obj.Close()
 	}
 	return s, nil
 }

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -211,7 +211,7 @@ func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 
 	err = openObjectAndSetSize(&obj, path)
 
-	return obj, nil
+	return obj, err
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and
@@ -321,10 +321,10 @@ func (s *storageFS) DeleteObject(bucketName, objectName string) error {
 // PatchObject patches the given object metadata.
 func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
-	defer obj.Close()
 	if err != nil {
 		return StreamingObject{}, err
 	}
+	defer obj.Close()
 	if obj.Metadata == nil {
 		obj.Metadata = map[string]string{}
 	}
@@ -337,10 +337,10 @@ func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[stri
 // UpdateObject replaces the given object metadata.
 func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
-	defer obj.Close()
 	if err != nil {
 		return StreamingObject{}, err
 	}
+	defer obj.Close()
 	obj.Metadata = map[string]string{}
 	for k, v := range metadata {
 		obj.Metadata[k] = v
@@ -373,10 +373,10 @@ func (s *storageFS) ComposeObject(bucketName string, objectNames []string, desti
 	var sourceObjects []StreamingObject
 	for _, n := range objectNames {
 		obj, err := s.GetObject(bucketName, n)
-		defer obj.Close()
 		if err != nil {
 			return StreamingObject{}, err
 		}
+		defer obj.Close()
 		sourceObjects = append(sourceObjects, obj)
 	}
 

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ type storageFS struct {
 }
 
 // NewStorageFS creates an instance of the filesystem-backed storage backend.
-func NewStorageFS(objects []Object, rootDir string) (Storage, error) {
+func NewStorageFS(objects []StreamingObject, rootDir string) (Storage, error) {
 	if !strings.HasSuffix(rootDir, "/") {
 		rootDir += "/"
 	}
@@ -135,10 +136,18 @@ func (s *storageFS) DeleteBucket(name string) error {
 	return os.RemoveAll(filepath.Join(s.rootDir, url.PathEscape(name)))
 }
 
-// CreateObject stores an object as a regular file in the disk.
-func (s *storageFS) CreateObject(obj Object) (Object, error) {
+// CreateObject stores an object as a regular file on disk. The backing content
+// for the object may be in the same file that's being updated, so a temporary
+// file is first created and then moved into place. This also makes it so any
+// object content readers currently open continue reading from the original
+// file instead of the newly created file.
+//
+// The crc32c checksum and md5 hash of the object content is calculated when
+// reading the object content. Any checksum or hash in the passed-in object
+// metadata is overwritten.
+func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 	if obj.Generation > 0 {
-		return Object{}, errors.New("not implemented: fs storage type does not support objects generation yet")
+		return StreamingObject{}, errors.New("not implemented: fs storage type does not support objects generation yet")
 	}
 
 	// Note: this was a quick fix for issue #701. Now that we have a way to
@@ -150,24 +159,57 @@ func (s *storageFS) CreateObject(obj Object) (Object, error) {
 	defer s.mtx.Unlock()
 	err := s.createBucket(obj.BucketName)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 
 	path := filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name))
 
-	if err = os.WriteFile(path, obj.Content, 0o600); err != nil {
-		return Object{}, err
+	tempFile, err := os.CreateTemp("", "fake-gcs-object")
+	if err != nil {
+		return StreamingObject{}, err
 	}
+	defer tempFile.Close()
+	// The file is renamed below, which causes this to be a no-op. If the
+	// function returns before the rename, though, the temp file will be
+	// removed.
+	defer os.RemoveAll(tempFile.Name())
+
+	err = os.Chmod(tempFile.Name(), 0o600)
+	if err != nil {
+		return StreamingObject{}, err
+	}
+
+	hasher := checksum.NewStreamingHasher()
+	objectContent := io.TeeReader(obj.Content, hasher)
+
+	if _, err = io.Copy(tempFile, objectContent); err != nil {
+		return StreamingObject{}, err
+	}
+
+	obj.Crc32c = hasher.EncodedCrc32cChecksum()
+	obj.Md5Hash = hasher.EncodedMd5Hash()
+	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
 
 	// TODO: Handle if metadata is not present more gracefully?
 	encoded, err := json.Marshal(obj.ObjectAttrs)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 
-	if err = writeXattr(path, encoded); err != nil {
-		return Object{}, err
+	if err = writeXattr(tempFile.Name(), encoded); err != nil {
+		return StreamingObject{}, err
 	}
+
+	err = os.Rename(tempFile.Name(), path)
+	if err != nil {
+		return StreamingObject{}, err
+	}
+
+	if err = renameXAttrFile(tempFile.Name(), path); err != nil {
+		return StreamingObject{}, err
+	}
+
+	err = openObjectAndSetSize(&obj, path)
 
 	return obj, nil
 }
@@ -198,14 +240,13 @@ func (s *storageFS) ListObjects(bucketName string, prefix string, versions bool)
 		if err != nil {
 			return nil, err
 		}
-		object.Size = int64(len(object.Content))
 		objects = append(objects, object.ObjectAttrs)
 	}
 	return objects, nil
 }
 
 // GetObject get an object by bucket and name.
-func (s *storageFS) GetObject(bucketName, objectName string) (Object, error) {
+func (s *storageFS) GetObject(bucketName, objectName string) (StreamingObject, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	return s.getObject(bucketName, objectName)
@@ -213,7 +254,7 @@ func (s *storageFS) GetObject(bucketName, objectName string) (Object, error) {
 
 // GetObjectWithGeneration retrieves an specific version of the object. Not
 // implemented for this backend.
-func (s *storageFS) GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error) {
+func (s *storageFS) GetObjectWithGeneration(bucketName, objectName string, generation int64) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {
 		return obj, err
@@ -224,28 +265,43 @@ func (s *storageFS) GetObjectWithGeneration(bucketName, objectName string, gener
 	return obj, nil
 }
 
-func (s *storageFS) getObject(bucketName, objectName string) (Object, error) {
+func (s *storageFS) getObject(bucketName, objectName string) (StreamingObject, error) {
 	path := filepath.Join(s.rootDir, url.PathEscape(bucketName), url.PathEscape(objectName))
 
 	encoded, err := readXattr(path)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 
-	var obj Object
+	var obj StreamingObject
 	if err = json.Unmarshal(encoded, &obj.ObjectAttrs); err != nil {
-		return Object{}, err
-	}
-
-	obj.Content, err = os.ReadFile(path)
-	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 
 	obj.Name = filepath.ToSlash(objectName)
 	obj.BucketName = bucketName
-	obj.Size = int64(len(obj.Content))
-	return obj, nil
+
+	err = openObjectAndSetSize(&obj, path)
+
+	return obj, err
+}
+
+func openObjectAndSetSize(obj *StreamingObject, path string) error {
+	// file is expected to be closed by the caller by calling obj.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	obj.Content = file
+	obj.Size = info.Size()
+
+	return nil
 }
 
 // DeleteObject deletes an object by bucket and name.
@@ -263,10 +319,11 @@ func (s *storageFS) DeleteObject(bucketName, objectName string) error {
 }
 
 // PatchObject patches the given object metadata.
-func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
+	defer obj.Close()
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 	if obj.Metadata == nil {
 		obj.Metadata = map[string]string{}
@@ -274,51 +331,65 @@ func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[stri
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
-	s.CreateObject(obj) // recreate object
-	return obj, nil
+	return s.CreateObject(obj) // recreate object
 }
 
 // UpdateObject replaces the given object metadata.
-func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
+	defer obj.Close()
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 	obj.Metadata = map[string]string{}
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
 	obj.Generation = 0
-	s.CreateObject(obj) // recreate object
-	return obj, nil
+	return s.CreateObject(obj) // recreate object
 }
 
-func (s *storageFS) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (Object, error) {
-	var data []byte
+type concatenatedContent struct {
+	io.Reader
+}
+
+func (c concatenatedContent) Close() error {
+	return errors.New("not implemented")
+}
+
+func (c concatenatedContent) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func concatObjectReaders(objects []StreamingObject) io.ReadSeekCloser {
+	readers := make([]io.Reader, len(objects))
+	for i := range objects {
+		readers[i] = objects[i].Content
+	}
+	return concatenatedContent{io.MultiReader(readers...)}
+}
+
+func (s *storageFS) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (StreamingObject, error) {
+	var sourceObjects []StreamingObject
 	for _, n := range objectNames {
 		obj, err := s.GetObject(bucketName, n)
+		defer obj.Close()
 		if err != nil {
-			return Object{}, err
+			return StreamingObject{}, err
 		}
-		data = append(data, obj.Content...)
+		sourceObjects = append(sourceObjects, obj)
 	}
 
-	dest, err := s.GetObject(bucketName, destinationName)
-	if err != nil {
-		oattrs := ObjectAttrs{
+	dest := StreamingObject{
+		ObjectAttrs: ObjectAttrs{
 			BucketName:  bucketName,
 			Name:        destinationName,
 			ContentType: contentType,
 			Created:     time.Now().String(),
-		}
-		dest = Object{
-			ObjectAttrs: oattrs,
-		}
+		},
 	}
 
-	dest.Content = data
-	dest.Crc32c = checksum.EncodedCrc32cChecksum(data)
-	dest.Md5Hash = checksum.EncodedMd5Hash(data)
+	dest.Content = concatObjectReaders(sourceObjects)
 	dest.Metadata = metadata
 
 	result, err := s.CreateObject(dest)

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -168,7 +168,13 @@ func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 	if err != nil {
 		return StreamingObject{}, err
 	}
-	defer tempFile.Close()
+	tempFile.Close()
+
+	tempFile, err = compatOpenForWritingAllowingRename(tempFile.Name())
+	if err != nil {
+		return StreamingObject{}, err
+	}
+
 	// The file is renamed below, which causes this to be a no-op. If the
 	// function returns before the rename, though, the temp file will be
 	// removed.

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -7,6 +7,7 @@ package backend
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,9 @@ func newBucketInMemory(name string, versioningEnabled bool) bucketInMemory {
 }
 
 func (bm *bucketInMemory) addObject(obj Object) Object {
+	obj.Crc32c = checksum.EncodedCrc32cChecksum(obj.Content)
+	obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
+	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
 	obj.Size = int64(len(obj.Content))
 	obj.Generation = getNewGenerationIfZero(obj.Generation)
 	index := findObject(obj, bm.activeObjects, false)
@@ -110,17 +114,21 @@ func findObject(obj Object, objectList []Object, matchGeneration bool) int {
 }
 
 // NewStorageMemory creates an instance of StorageMemory.
-func NewStorageMemory(objects []Object) Storage {
+func NewStorageMemory(objects []StreamingObject) (Storage, error) {
 	s := &storageMemory{
 		buckets: make(map[string]bucketInMemory),
 	}
 	for _, o := range objects {
+		bufferedObject, err := o.BufferedObject()
+		if err != nil {
+			return nil, err
+		}
 		s.CreateBucket(o.BucketName, false)
 		bucket := s.buckets[o.BucketName]
-		bucket.addObject(o)
+		bucket.addObject(bufferedObject)
 		s.buckets[o.BucketName] = bucket
 	}
-	return s
+	return s, nil
 }
 
 // CreateBucket creates a bucket.
@@ -181,20 +189,24 @@ func (s *storageMemory) DeleteBucket(name string) error {
 }
 
 // CreateObject stores an object in the backend.
-func (s *storageMemory) CreateObject(obj Object) (Object, error) {
+func (s *storageMemory) CreateObject(obj StreamingObject) (StreamingObject, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	bucketInMemory, err := s.getBucketInMemory(obj.BucketName)
 	if err != nil {
 		bucketInMemory = newBucketInMemory(obj.BucketName, false)
 	}
-	newObj := bucketInMemory.addObject(obj)
+	bufferedObj, err := obj.BufferedObject()
+	if err != nil {
+		return StreamingObject{}, err
+	}
+	newObj := bucketInMemory.addObject(bufferedObj)
 	s.buckets[obj.BucketName] = bucketInMemory
-	return newObj, nil
+	return newObj.StreamingObject(), nil
 }
 
 // ListObjects lists the objects in a given bucket with a given prefix and
-// delimeter.
+// delimiter.
 func (s *storageMemory) ListObjects(bucketName string, prefix string, versions bool) ([]ObjectAttrs, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
@@ -223,17 +235,17 @@ func (s *storageMemory) ListObjects(bucketName string, prefix string, versions b
 	return append(objAttrs, archvObjs...), nil
 }
 
-func (s *storageMemory) GetObject(bucketName, objectName string) (Object, error) {
+func (s *storageMemory) GetObject(bucketName, objectName string) (StreamingObject, error) {
 	return s.GetObjectWithGeneration(bucketName, objectName, 0)
 }
 
 // GetObjectWithGeneration retrieves a specific version of the object.
-func (s *storageMemory) GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error) {
+func (s *storageMemory) GetObjectWithGeneration(bucketName, objectName string, generation int64) (StreamingObject, error) {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	bucketInMemory, err := s.getBucketInMemory(bucketName)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 	matchGeneration := false
 	obj := Object{ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName}}
@@ -245,10 +257,10 @@ func (s *storageMemory) GetObjectWithGeneration(bucketName, objectName string, g
 	}
 	index := findObject(obj, listToConsider, matchGeneration)
 	if index < 0 {
-		return obj, errors.New("object not found")
+		return obj.StreamingObject(), errors.New("object not found")
 	}
 
-	return listToConsider[index], nil
+	return listToConsider[index].StreamingObject(), nil
 }
 
 func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
@@ -262,16 +274,20 @@ func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
 	if err != nil {
 		return err
 	}
-	bucketInMemory.deleteObject(obj, true)
+	bufferedObject, err := obj.BufferedObject()
+	if err != nil {
+		return err
+	}
+	bucketInMemory.deleteObject(bufferedObject, true)
 	s.buckets[bucketName] = bucketInMemory
 	return nil
 }
 
 // PatchObject updates an object metadata.
-func (s *storageMemory) PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+func (s *storageMemory) PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 	if obj.Metadata == nil {
 		obj.Metadata = map[string]string{}
@@ -284,10 +300,10 @@ func (s *storageMemory) PatchObject(bucketName, objectName string, metadata map[
 }
 
 // UpdateObject replaces an object metadata.
-func (s *storageMemory) UpdateObject(bucketName, objectName string, metadata map[string]string) (Object, error) {
+func (s *storageMemory) UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {
-		return Object{}, err
+		return StreamingObject{}, err
 	}
 	obj.Metadata = map[string]string{}
 	for k, v := range metadata {
@@ -297,17 +313,22 @@ func (s *storageMemory) UpdateObject(bucketName, objectName string, metadata map
 	return obj, nil
 }
 
-func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (Object, error) {
+func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (StreamingObject, error) {
 	var data []byte
 	for _, n := range objectNames {
 		obj, err := s.GetObject(bucketName, n)
 		if err != nil {
-			return Object{}, err
+			return StreamingObject{}, err
 		}
-		data = append(data, obj.Content...)
+		objectContent, err := io.ReadAll(obj.Content)
+		if err != nil {
+			return StreamingObject{}, err
+		}
+		data = append(data, objectContent...)
 	}
 
-	dest, err := s.GetObject(bucketName, destinationName)
+	var dest Object
+	streamingDest, err := s.GetObject(bucketName, destinationName)
 	if err != nil {
 		dest = Object{
 			ObjectAttrs: ObjectAttrs{
@@ -317,14 +338,20 @@ func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, d
 				Created:     time.Now().String(),
 			},
 		}
+	} else {
+		dest, err = streamingDest.BufferedObject()
+		if err != nil {
+			return StreamingObject{}, err
+		}
 	}
 
 	dest.Content = data
 	dest.Crc32c = checksum.EncodedCrc32cChecksum(data)
 	dest.Md5Hash = checksum.EncodedMd5Hash(data)
+	dest.Etag = fmt.Sprintf("%q", dest.Md5Hash)
 	dest.Metadata = metadata
 
-	result, err := s.CreateObject(dest)
+	result, err := s.CreateObject(dest.StreamingObject())
 	if err != nil {
 		return result, err
 	}

--- a/internal/backend/rename_unix.go
+++ b/internal/backend/rename_unix.go
@@ -1,0 +1,14 @@
+package backend
+
+// This file contains open and rename functions for Windows compatibility. See
+// rename_windoes.go for details.
+
+import "os"
+
+func compatOpenAllowingRename(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
+func compatRename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/internal/backend/rename_unix.go
+++ b/internal/backend/rename_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package backend
 
 // This file contains open and rename functions for Windows compatibility. See

--- a/internal/backend/rename_unix.go
+++ b/internal/backend/rename_unix.go
@@ -12,6 +12,10 @@ func compatOpenAllowingRename(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
+func compatOpenForWritingAllowingRename(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
+}
+
 func compatRename(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)
 }

--- a/internal/backend/rename_windows.go
+++ b/internal/backend/rename_windows.go
@@ -1,0 +1,47 @@
+package backend
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/alexbrainman/goissue34681"
+)
+
+// compatOpenAllowingRename opens the file at the given path using the
+// FILE_SHARE_DELETE flag, which allows opened files to be renamed and deleted
+// on Windows.
+func compatOpenAllowingRename(path string) (*os.File, error) {
+	return goissue34681.Open(path)
+}
+
+// compatRename renames a file and handles the case where the rename
+// destination already exists and might be open (open files must have been
+// opened using compatOpenAllowingRename).
+//
+// See the following for more information:
+// https://boostgsoc13.github.io/boost.afio/doc/html/afio/FAQ/deleting_open_files.html
+// https://github.com/golang/go/issues/34681
+// https://github.com/golang/go/issues/32088
+func compatRename(oldpath, newpath string) error {
+	_, err := os.Stat(newpath)
+	if os.IsExist(err) {
+		tempDeletePath := fmt.Sprintf("%s-overwritten-%d", newpath, time.Now().UnixMilli())
+		// Move the destination to a "temporary delete path" so newpath is
+		// freed up before we perform the rename below.
+		err = os.Rename(newpath, tempDeletePath)
+		if err != nil {
+			return fmt.Errorf("count not move destination file during rename, %w", err)
+		}
+		// Delete the "temporary delete path". If there are any open file
+		// descriptors (e.g. for objects currently being read), it's still
+		// possible to read the original contents from the file; the file will
+		// be removed from the directory sometime after the last descriptor is
+		// closed.
+		err = os.Remove(tempDeletePath)
+		if err != nil {
+			return fmt.Errorf("count not delete destination file during rename, %w", err)
+		}
+	}
+	return os.Rename(oldpath, newpath)
+}

--- a/internal/backend/rename_windows.go
+++ b/internal/backend/rename_windows.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/alexbrainman/goissue34681"
@@ -30,7 +31,9 @@ func compatOpenForWritingAllowingRename(path string) (*os.File, error) {
 func compatRename(oldpath, newpath string) error {
 	_, err := os.Stat(newpath)
 	if os.IsExist(err) {
-		tempDeletePath := fmt.Sprintf("%s-overwritten-%d", newpath, time.Now().UnixMilli())
+		tempDeletePath := filepath.Join(
+			os.TempDir(),
+			fmt.Sprintf("%s-overwritten-%d", newpath, time.Now().UnixMilli()))
 		// Move the destination to a "temporary delete path" so newpath is
 		// freed up before we perform the rename below.
 		err = os.Rename(newpath, tempDeletePath)

--- a/internal/backend/rename_windows.go
+++ b/internal/backend/rename_windows.go
@@ -15,6 +15,10 @@ func compatOpenAllowingRename(path string) (*os.File, error) {
 	return goissue34681.Open(path)
 }
 
+func compatOpenForWritingAllowingRename(path string) (*os.File, error) {
+	return goissue34681.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
+}
+
 // compatRename renames a file and handles the case where the rename
 // destination already exists and might be open (open files must have been
 // opened using compatOpenAllowingRename).

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -12,14 +12,14 @@ type Storage interface {
 	ListBuckets() ([]Bucket, error)
 	GetBucket(name string) (Bucket, error)
 	DeleteBucket(name string) error
-	CreateObject(obj Object) (Object, error)
+	CreateObject(obj StreamingObject) (StreamingObject, error)
 	ListObjects(bucketName string, prefix string, versions bool) ([]ObjectAttrs, error)
-	GetObject(bucketName, objectName string) (Object, error)
-	GetObjectWithGeneration(bucketName, objectName string, generation int64) (Object, error)
+	GetObject(bucketName, objectName string) (StreamingObject, error)
+	GetObjectWithGeneration(bucketName, objectName string, generation int64) (StreamingObject, error)
 	DeleteObject(bucketName, objectName string) error
-	PatchObject(bucketName, objectName string, metadata map[string]string) (Object, error)
-	UpdateObject(bucketName, objectName string, metadata map[string]string) (Object, error)
-	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (Object, error)
+	PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error)
+	UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error)
+	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (StreamingObject, error)
 }
 
 type Error string

--- a/internal/backend/xattr_unix.go
+++ b/internal/backend/xattr_unix.go
@@ -28,3 +28,7 @@ func isXattrFile(path string) bool {
 func removeXattrFile(path string) error {
 	return nil
 }
+
+func renameXAttrFile(pathSrc, pathDst string) error {
+	return nil
+}

--- a/internal/backend/xattr_windows.go
+++ b/internal/backend/xattr_windows.go
@@ -31,5 +31,5 @@ func removeXattrFile(path string) error {
 }
 
 func renameXAttrFile(pathSrc, pathDst string) error {
-	return os.Rename(pathSrc+xattrKey, pathDst+xattrKey)
+	return compatRename(pathSrc+xattrKey, pathDst+xattrKey)
 }

--- a/internal/backend/xattr_windows.go
+++ b/internal/backend/xattr_windows.go
@@ -29,3 +29,7 @@ func isXattrFile(path string) bool {
 func removeXattrFile(path string) error {
 	return os.Remove(path + xattrKey)
 }
+
+func renameXAttrFile(pathSrc, pathDst string) error {
+	return os.Rename(pathSrc+xattrKey, pathDst+xattrkey)
+}

--- a/internal/backend/xattr_windows.go
+++ b/internal/backend/xattr_windows.go
@@ -31,5 +31,5 @@ func removeXattrFile(path string) error {
 }
 
 func renameXAttrFile(pathSrc, pathDst string) error {
-	return os.Rename(pathSrc+xattrKey, pathDst+xattrkey)
+	return os.Rename(pathSrc+xattrKey, pathDst+xattrKey)
 }

--- a/internal/notification/event.go
+++ b/internal/notification/event.go
@@ -52,7 +52,7 @@ type EventManagerOptions struct {
 }
 
 type EventManager interface {
-	Trigger(o *backend.Object, eventType EventType, extraEventAttr map[string]string)
+	Trigger(o *backend.StreamingObject, eventType EventType, extraEventAttr map[string]string)
 }
 
 // PubsubEventManager checks if an event should be published.
@@ -96,7 +96,7 @@ type eventPublisher interface {
 
 // Trigger checks if an event should be triggered. If so, it publishes the
 // event to a pubsub queue.
-func (m *PubsubEventManager) Trigger(o *backend.Object, eventType EventType, extraEventAttr map[string]string) {
+func (m *PubsubEventManager) Trigger(o *backend.StreamingObject, eventType EventType, extraEventAttr map[string]string) {
 	if m.publisher == nil {
 		return
 	}
@@ -139,7 +139,7 @@ func (m *PubsubEventManager) Trigger(o *backend.Object, eventType EventType, ext
 	}
 }
 
-func (m *PubsubEventManager) publish(o *backend.Object, eventType EventType, eventTime string, extraEventAttr map[string]string) error {
+func (m *PubsubEventManager) publish(o *backend.StreamingObject, eventType EventType, eventTime string, extraEventAttr map[string]string) error {
 	ctx := context.Background()
 	data, attributes, err := generateEvent(o, eventType, eventTime, extraEventAttr)
 	if err != nil {
@@ -175,7 +175,7 @@ type gcsEvent struct {
 	MetaData        map[string]string `json:"metadata,omitempty"`
 }
 
-func generateEvent(o *backend.Object, eventType EventType, eventTime string, extraEventAttr map[string]string) ([]byte, map[string]string, error) {
+func generateEvent(o *backend.StreamingObject, eventType EventType, eventTime string, extraEventAttr map[string]string) ([]byte, map[string]string, error) {
 	payload := gcsEvent{
 		Kind:            "storage#object",
 		ID:              o.ID(),
@@ -187,7 +187,7 @@ func generateEvent(o *backend.Object, eventType EventType, eventTime string, ext
 		Created:         o.Created,
 		Updated:         o.Updated,
 		StorageClass:    "STANDARD",
-		Size:            strconv.Itoa(len(o.Content)),
+		Size:            strconv.FormatInt(o.Size, 10),
 		MD5Hash:         o.Md5Hash,
 		CRC32c:          o.Crc32c,
 		MetaData:        o.Metadata,

--- a/internal/notification/event_test.go
+++ b/internal/notification/event_test.go
@@ -95,7 +95,16 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			obj := backend.Object{ObjectAttrs: backend.ObjectAttrs{BucketName: "some-bucket", Name: "files/txt/text-01.txt"}, Content: []byte("something")}
+			content := []byte("something")
+			bufferedObj := backend.Object{
+				ObjectAttrs: backend.ObjectAttrs{
+					BucketName: "some-bucket",
+					Name:       "files/txt/text-01.txt",
+					Size:       int64(len(content)),
+				},
+				Content: content,
+			}
+			obj := bufferedObj.StreamingObject()
 			eventManager := PubsubEventManager{
 				notifyOn:     test.notifyOn,
 				objectPrefix: test.prefix,
@@ -133,10 +142,10 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 						t.Errorf("wrong bucket on object\nwant %q\ngot %q", obj.BucketName, receivedEvent.Bucket)
 					}
 					if obj.Name != receivedEvent.Name {
-						t.Errorf("wrong objectc name\nwant %q\ngot %q", obj.Name, receivedEvent.Name)
+						t.Errorf("wrong object name\nwant %q\ngot %q", obj.Name, receivedEvent.Name)
 					}
-					if strconv.Itoa(len(obj.Content)) != receivedEvent.Size {
-						t.Errorf("wrong object size\nwant %q\ngot %q", strconv.Itoa(len(obj.Content)), receivedEvent.Size)
+					if strconv.Itoa(len(bufferedObj.Content)) != receivedEvent.Size {
+						t.Errorf("wrong object size\nwant %q\ngot %q", strconv.Itoa(len(bufferedObj.Content)), receivedEvent.Size)
 					}
 					if !reflect.DeepEqual(test.metadata, receivedEvent.MetaData) {
 						t.Errorf("wrong object metadata\nwant %q\ngot %q", test.metadata, receivedEvent.MetaData)


### PR DESCRIPTION
Fixes #828. (This is #829 with the review requests applied)

This PR makes it so objects in the FS backend are streamed from disk instead of being loaded into memory. This drastically reduces memory usage when working with large files, especially when performing small concurrent range reads on a large file.

A StreamingObject type has been added to both the fakestorage and backend packages. This type contains a io.ReadSeekCloser that can be used to access object data.

This change sets the stage for fixing #669 and #397. #669 isn't fixed because it will require re-working of how resumable uploads are stored (though other upload types have been made streaming in this PR). Also, fixing #397 would require changing how initial objects are specified when starting the server, which with this approach would require changing the public API.

Regarding the public API: the server methods for working with objects have been changed to use StreamingObject instead of Object. This is a breaking change. It would be possible to make streaming backward compatible by adding some metadata and methods to Object (to distinguish between streaming and buffered objects), but I went with this approach because it made identifying the code that needed to be updated easier; the compiler pointed out the locations to update instead of needing to track down runtime and test errors. An additional improvement, which is compatible with the backward compatible approach, would be to add an OpenForReading method on Object so callers that are currently responsible for closing objects also explicitly open objects (which would make the responsibility clearer). Anyway, I wanted to get this initial approach up for feedback before putting in additional work.

