### PR TITLE
backend/fs: place temporary file in the destination directory

### DIFF
--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -167,7 +167,7 @@ func (s *storageFS) CreateObject(obj StreamingObject) (StreamingObject, error) {
 
 	path := filepath.Join(s.rootDir, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name))
 
-	tempFile, err := os.CreateTemp("", "fake-gcs-object")
+	tempFile, err := os.CreateTemp(filepath.Dir(path), "fake-gcs-object")
 	if err != nil {
 		return StreamingObject{}, err
 	}


### PR DESCRIPTION
This should guarantee that we can rename it. Well, unless we run into
some weird underlying filesystem that doesn't support renaming, but
hopefully we don't have to cross that bridge.

Closes #912.