### PR TITLE
Format "generation" field in Pubsub notification as a string

### DIFF
--- a/internal/notification/event.go
+++ b/internal/notification/event.go
@@ -155,21 +155,21 @@ func (m *PubsubEventManager) publish(o *backend.StreamingObject, eventType Event
 	return nil
 }
 
-// gcsEvent is the payload of a GCS event.  The description of the full object
-// can be found here:
+// gcsEvent is the payload of a GCS event. Note that all properties are string-quoted.
+// The description of the full object can be found here:
 // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations.
 type gcsEvent struct {
 	Kind            string            `json:"kind"`
 	ID              string            `json:"id"`
 	Name            string            `json:"name"`
 	Bucket          string            `json:"bucket"`
-	Generation      int64             `json:"generation,omitempty"`
+	Generation      int64             `json:"generation,string,omitempty"`
 	ContentType     string            `json:"contentType"`
 	ContentEncoding string            `json:"contentEncoding,omitempty"`
 	Created         string            `json:"timeCreated,omitempty"`
 	Updated         string            `json:"updated,omitempty"`
 	StorageClass    string            `json:"storageClass"`
-	Size            string            `json:"size"`
+	Size            int64             `json:"size,string"`
 	MD5Hash         string            `json:"md5Hash,omitempty"`
 	CRC32c          string            `json:"crc32c,omitempty"`
 	MetaData        map[string]string `json:"metadata,omitempty"`
@@ -187,7 +187,7 @@ func generateEvent(o *backend.StreamingObject, eventType EventType, eventTime st
 		Created:         o.Created,
 		Updated:         o.Updated,
 		StorageClass:    "STANDARD",
-		Size:            strconv.FormatInt(o.Size, 10),
+		Size:            o.Size,
 		MD5Hash:         o.Md5Hash,
 		CRC32c:          o.Crc32c,
 		MetaData:        o.Metadata,

--- a/internal/notification/event_test.go
+++ b/internal/notification/event_test.go
@@ -144,7 +144,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 					if obj.Name != receivedEvent.Name {
 						t.Errorf("wrong object name\nwant %q\ngot %q", obj.Name, receivedEvent.Name)
 					}
-					if strconv.Itoa(len(bufferedObj.Content)) != receivedEvent.Size {
+					if int64(len(bufferedObj.Content)) != receivedEvent.Size {
 						t.Errorf("wrong object size\nwant %q\ngot %q", strconv.Itoa(len(bufferedObj.Content)), receivedEvent.Size)
 					}
 					if !reflect.DeepEqual(test.metadata, receivedEvent.MetaData) {


### PR DESCRIPTION
As documented in the storage objects JSON object representation, all fields are "string formatted as the specified value type", including numbers.

https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations

`strconv.FormatInt` was used for the "size" field, but this wasn't done for generation.

We noticed this when doing local testing, and the messages failed JSON unmarshalling from fake-gcs-server, but were properly unmarshalling from real Google Cloud Storage pubsub messages.

<img width="740" alt="Screen Shot 2022-10-28 at 12 20 35 PM" src="https://user-images.githubusercontent.com/87710586/198714128-eed9fb30-9b18-46ec-937e-a4566350c3de.png">

<img width="479" alt="Screen Shot 2022-10-28 at 12 20 39 PM" src="https://user-images.githubusercontent.com/87710586/198714137-6a2536c8-0d69-44e1-bc69-13c8da6e8839.png">
