### PR TITLE
Add default ACL for predefined blobs

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/fsouza/fake-gcs-server/internal/checksum"
 	"github.com/fsouza/fake-gcs-server/internal/config"
@@ -101,6 +102,12 @@ func objectsFromBucket(localBucketPath, bucketName string) ([]fakestorage.Object
 			if err != nil {
 				return fmt.Errorf("could not read file %q: %w", path, err)
 			}
+			defaultACL := []storage.ACLRule{
+				{
+					Entity: "projectOwner-test-project",
+					Role:   "OWNER",
+				},
+			}
 			objects = append(objects, fakestorage.Object{
 				ObjectAttrs: fakestorage.ObjectAttrs{
 					BucketName:  bucketName,
@@ -108,6 +115,7 @@ func objectsFromBucket(localBucketPath, bucketName string) ([]fakestorage.Object
 					ContentType: mime.TypeByExtension(filepath.Ext(path)),
 					Crc32c:      checksum.EncodedCrc32cChecksum(fileContent),
 					Md5Hash:     checksum.EncodedMd5Hash(fileContent),
+					ACL:         defaultACL,
 				},
 				Content: fileContent,
 			})


### PR DESCRIPTION
This fixes #944

I assumed that for any blob that is preloaded into a bucket, the ACL for each of them would just be `[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]`

The following python snippet now no longer crashes (although the issue #945 still remains unresolved, I am looking into this bug and hope to make a fix in the near future):
```
os.environ["STORAGE_EMULATOR_HOST"] = "http://0.0.0.0:4443"

client = storage.Client(
    credentials=AnonymousCredentials(),
    project="test-project",
)

# initial bucket/file for docker image
bucket_name = "sample-bucket"
blob_name = "some_file.txt"

# test
bucket = client.get_bucket(bucket_name)
blob = bucket.blob(blob_name)
print(list(blob.acl))
blob.make_public() 
blob.make_private()
```