### PR TITLE
Fix ACL errors for newly created and pre-existing blobs

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -934,17 +934,37 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	vars := unescapeMuxVars(mux.Vars(r))
 	bucketName := vars["bucketName"]
 	objectName := vars["objectName"]
-	var metadata struct {
-		Metadata map[string]string `json:"metadata"`
+
+	type acls struct {
+		Entity string
+		Role   string
 	}
-	err := json.NewDecoder(r.Body).Decode(&metadata)
+
+	var payload struct {
+		Metadata map[string]string `json:"metadata"`
+		Acl      []acls
+	}
+	err := json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
 		return jsonResponse{
 			status:       http.StatusBadRequest,
 			errorMessage: "Metadata in the request couldn't decode",
 		}
 	}
-	backendObj, err := s.backend.PatchObject(bucketName, objectName, metadata.Metadata)
+
+	var attrsToUpdate backend.ObjectAttrs
+
+	attrsToUpdate.Metadata = payload.Metadata
+
+	if len(payload.Acl) > 0 {
+		attrsToUpdate.ACL = []storage.ACLRule{}
+		for _, aclData := range payload.Acl {
+			newAcl := storage.ACLRule{Entity: storage.ACLEntity(aclData.Entity), Role: storage.ACLRole(aclData.Role)}
+			attrsToUpdate.ACL = append(attrsToUpdate.ACL, newAcl)
+		}
+	}
+
+	backendObj, err := s.backend.PatchObject(bucketName, objectName, attrsToUpdate)
 	if err != nil {
 		return jsonResponse{
 			status:       http.StatusNotFound,

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -310,7 +310,6 @@ func (s *storageFS) DeleteObject(bucketName, objectName string) error {
 	return os.Remove(path)
 }
 
-// func (s *storageFS) PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 func (s *storageFS) PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {
@@ -323,7 +322,6 @@ func (s *storageFS) PatchObject(bucketName, objectName string, attrsToUpdate Obj
 	return s.CreateObject(obj, NoConditions{})
 }
 
-// UpdateObject replaces the given object metadata.
 func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 	"syscall"
@@ -319,24 +318,7 @@ func (s *storageFS) PatchObject(bucketName, objectName string, attrsToUpdate Obj
 	}
 	defer obj.Close()
 
-	currObjValues := reflect.ValueOf(&(obj.ObjectAttrs)).Elem()
-	currObjType := currObjValues.Type()
-	newObjValues := reflect.ValueOf(attrsToUpdate)
-	for i := 0; i < newObjValues.NumField(); i++ {
-		if reflect.Value.IsZero(newObjValues.Field(i)) {
-			continue
-		} else if currObjType.Field(i).Name == "Metadata" {
-			if obj.Metadata == nil {
-				obj.Metadata = map[string]string{}
-			}
-			for k, v := range attrsToUpdate.Metadata {
-				obj.Metadata[k] = v
-			}
-		} else {
-			currObjValues.Field(i).Set(newObjValues.Field(i))
-		}
-	}
-
+	obj.patch(attrsToUpdate)
 	obj.Generation = 0 // reset generation id
 	return s.CreateObject(obj, NoConditions{})
 }
@@ -352,8 +334,8 @@ func (s *storageFS) UpdateObject(bucketName, objectName string, metadata map[str
 	for k, v := range metadata {
 		obj.Metadata[k] = v
 	}
-	obj.Generation = 0                         // reset generation id
-	return s.CreateObject(obj, NoConditions{}) // recreate object
+	obj.Generation = 0 // reset generation id
+	return s.CreateObject(obj, NoConditions{})
 }
 
 type concatenatedContent struct {

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -299,7 +299,6 @@ func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
 	return nil
 }
 
-// PatchObject updates an object metadata.
 func (s *storageMemory) PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -300,18 +301,30 @@ func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
 }
 
 // PatchObject updates an object metadata.
-func (s *storageMemory) PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error) {
+func (s *storageMemory) PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {
 		return StreamingObject{}, err
 	}
-	if obj.Metadata == nil {
-		obj.Metadata = map[string]string{}
+
+	currObjValues := reflect.ValueOf(&(obj.ObjectAttrs)).Elem()
+	currObjType := currObjValues.Type()
+	newObjValues := reflect.ValueOf(attrsToUpdate)
+	for i := 0; i < newObjValues.NumField(); i++ {
+		if reflect.Value.IsZero(newObjValues.Field(i)) {
+			continue
+		} else if currObjType.Field(i).Name == "Metadata" {
+			if obj.Metadata == nil {
+				obj.Metadata = map[string]string{}
+			}
+			for k, v := range attrsToUpdate.Metadata {
+				obj.Metadata[k] = v
+			}
+		} else {
+			currObjValues.Field(i).Set(newObjValues.Field(i))
+		}
 	}
-	for k, v := range metadata {
-		obj.Metadata[k] = v
-	}
-	s.CreateObject(obj, NoConditions{}) // recreate object
+	s.CreateObject(obj, NoConditions{})
 	return obj, nil
 }
 

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -27,7 +27,7 @@ type Storage interface {
 	GetObject(bucketName, objectName string) (StreamingObject, error)
 	GetObjectWithGeneration(bucketName, objectName string, generation int64) (StreamingObject, error)
 	DeleteObject(bucketName, objectName string) error
-	PatchObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error)
+	PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error)
 	UpdateObject(bucketName, objectName string, metadata map[string]string) (StreamingObject, error)
 	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string) (StreamingObject, error)
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/fsouza/fake-gcs-server/internal/checksum"
 	"github.com/fsouza/fake-gcs-server/internal/config"
@@ -103,6 +104,12 @@ func objectsFromBucket(localBucketPath, bucketName string) ([]fakestorage.Object
 			}
 			objects = append(objects, fakestorage.Object{
 				ObjectAttrs: fakestorage.ObjectAttrs{
+					ACL: []storage.ACLRule{
+						{
+							Entity: "projectOwner-test-project",
+							Role:   "OWNER",
+						},
+					},
 					BucketName:  bucketName,
 					Name:        objectKey,
 					ContentType: mime.TypeByExtension(filepath.Ext(path)),

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"testing"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -48,6 +49,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 			expectedObjects: []fakestorage.Object{
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "sample-bucket",
 						Name:        "some_file.txt",
 						ContentType: testContentType,
@@ -63,6 +70,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 			expectedObjects: []fakestorage.Object{
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "some-bucket",
 						Name:        "a/b/c/d/e/f/object1.txt",
 						ContentType: testContentType,
@@ -71,6 +84,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 				},
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "some-bucket",
 						Name:        "a/b/c/d/e/f/object2.txt",
 						ContentType: testContentType,
@@ -79,6 +98,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 				},
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "some-bucket",
 						Name:        "root-object.txt",
 						ContentType: testContentType,
@@ -101,6 +126,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 			expectedObjects: []fakestorage.Object{
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "bucket1",
 						Name:        "object1.txt",
 						ContentType: testContentType,
@@ -109,6 +140,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 				},
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "bucket1",
 						Name:        "object2.txt",
 						ContentType: testContentType,
@@ -117,6 +154,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 				},
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "bucket2",
 						Name:        "object1.txt",
 						ContentType: testContentType,
@@ -125,6 +168,12 @@ func TestGenerateObjectsFromFiles(t *testing.T) {
 				},
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
+						ACL: []storage.ACLRule{
+							{
+								Entity: "projectOwner-test-project",
+								Role:   "OWNER",
+							},
+						},
 						BucketName:  "bucket2",
 						Name:        "object2.txt",
 						ContentType: testContentType,


### PR DESCRIPTION
This fixes #944 and fixes #945.

The following two python snippets no longer crash and instead give the correct output. The first one is for a pre-existing blob (thus fixing #944):

```
os.environ["STORAGE_EMULATOR_HOST"] = "http://0.0.0.0:4443"

client = storage.Client(
    credentials=AnonymousCredentials(),
    project="test-project",
)

# initial bucket/file for docker image
bucket_name = "sample-bucket"
blob_name = "some_file.txt"

# test
bucket = client.get_bucket(bucket_name)
blob = bucket.blob(blob_name)
print(list(blob.acl))
blob.make_public() 
print(list(blob.acl))
blob.make_private()
print(list(blob.acl))
```
The outputs:
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}, {'entity': 'allUsers', 'role': 'READER'}]
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]

The second snippet shows how for a newly created blob, the acl's also update when make_public() and make_private() are called:
```
os.environ["STORAGE_EMULATOR_HOST"] = "http://0.0.0.0:4443"

client = storage.Client(
    credentials=AnonymousCredentials(),
    project="test-project",
)

# buckets/files to create and test
upload_bucket_name = "test-bucket-with-globally-unique-name"
upload_blob_name = "test-blob-upload.svg"
upload_blob_file_path = "./image.svg"

# initialize
try:
    bucket = client.bucket(upload_bucket_name)
    bucket.storage_class = storage.constants.STANDARD_STORAGE_CLASS
    client.create_bucket(bucket, location="EU", retry=None)
except:
    pass
bucket = client.get_bucket(upload_bucket_name)
blob = bucket.blob(upload_blob_name)
blob.upload_from_filename(upload_blob_file_path, retry=None)

# test
bucket = client.get_bucket(upload_bucket_name)
blob = bucket.blob(upload_blob_name)
print(list(blob.acl))
blob.make_public()
print(list(blob.acl)) 
blob.make_private()
print(list(blob.acl))
```
The outputs:
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}, {'entity': 'allUsers', 'role': 'READER'}]
[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]

Explanation of my implementation:

For fixing #944:
Within main.go, when it reads all the existing files within the bucket, it previously never set an ACL for any of these objects. I assumed that for these pre-existing blobs, the ACL for each of them would just be `[{'entity': 'projectOwner-test-project', 'role': 'OWNER'}]`.

For fixing #945:
From looking at how the python API updates the ACL's, I found that rather than sending a POST to the endpoint `/b/{bucketName}/o/{objectName:.+}/acl`, it instead sends a PATCH request to the endpoint `/b/{bucketName}/o/{objectName:.+}`. 

Thus, I needed to update the `patchObject` method within `fakestorage/object.go` to detect if new ACL's are passed in and update the object's ACL if so. 