### PR TITLE
Do not escape the object name in the fs backend

### DIFF
--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -231,7 +231,8 @@ func (s *storageFS) ListObjects(bucketName string, prefix string, versions bool)
 	// TODO: WalkDir more efficient?
 	bucketPath := filepath.Join(s.rootDir, url.PathEscape(bucketName))
 	if err := filepath.Walk(bucketPath, func(path string, info fs.FileInfo, _ error) error {
-		objName := filepath.Rel(bucketPath, path)
+		// Rel() should never return error since path always descend from bucketPath
+		objName, _ := filepath.Rel(bucketPath, path)
 		// TODO: should this check path?
 		if s.mh.isSpecialFile(info.Name()) {
 			return nil

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -231,7 +231,7 @@ func (s *storageFS) ListObjects(bucketName string, prefix string, versions bool)
 	// TODO: WalkDir more efficient?
 	bucketPath := filepath.Join(s.rootDir, url.PathEscape(bucketName))
 	if err := filepath.Walk(bucketPath, func(path string, info fs.FileInfo, _ error) error {
-		objName := strings.TrimPrefix(path, bucketPath+string(filepath.Separator))
+		objName := filepath.Rel(bucketPath, path)
 		// TODO: should this check path?
 		if s.mh.isSpecialFile(info.Name()) {
 			return nil


### PR DESCRIPTION
Now fake-gcs-server implicitly creates parent directories when creating an object `/foo/bar/baz`.  This allows creating paths longer than `NAME_MAX` (256) and interoperating with existing filesystems.  This approach does not allow some kinds of objects to exist, e.g., `/foo/` with a non-zero object size, although these should be rare.