### PR TITLE
Make resumable uploads work from browser with signed url

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -813,6 +813,7 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	for name, value := range obj.Metadata {
 		w.Header().Set("X-Goog-Meta-"+name, value)
 	}
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	if ranged && !satisfiable {
 		status = http.StatusRequestedRangeNotSatisfiable

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -125,7 +125,7 @@ func NewServerWithOptions(options Options) (*Server, error) {
 		return nil, err
 	}
 
-	allowedHeaders := []string{"Content-Type", "Content-Encoding", "Range"}
+	allowedHeaders := []string{"Content-Type", "Content-Encoding", "Range", "Content-Range"}
 	allowedHeaders = append(allowedHeaders, options.AllowedCORSHeaders...)
 
 	cors := handlers.CORS(

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -140,6 +140,7 @@ func NewServerWithOptions(options Options) (*Server, error) {
 		handlers.AllowedHeaders(allowedHeaders),
 		handlers.AllowedOrigins([]string{"*"}),
 		handlers.AllowCredentials(),
+		handlers.ExposedHeaders([]string{"Location"}),
 	)
 
 	handler := cors(s.mux)


### PR DESCRIPTION
These headers are necessary to make browser originated signed url requests work.

I don't know go, and these edits likely should be handled at a different level/more comprehensively. Happy to modify and repush if you've got feedback. If not, this PR could be a good sketch for better updates to support browser based signed url requests.