### PR TITLE
Add ability to change log level

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fsouza/fake-gcs-server/internal/notification"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -38,6 +39,7 @@ func TestLoadConfig(t *testing.T) {
 				"-event.object-prefix", "uploads/",
 				"-event.list", "finalize,delete,metadataUpdate,archive",
 				"-location", "US-EAST1",
+				"-log-level", "warn",
 			},
 			expectedConfig: Config{
 				Seed:               "/var/gcs",
@@ -56,6 +58,7 @@ func TestLoadConfig(t *testing.T) {
 					list:            []string{"finalize", "delete", "metadataUpdate", "archive"},
 				},
 				bucketLocation: "US-EAST1",
+				LogLevel:       logrus.WarnLevel,
 			},
 		},
 		{
@@ -74,6 +77,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
+				LogLevel:       logrus.InfoLevel,
 			},
 		},
 		{
@@ -109,6 +113,11 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name:      "invalid events",
 			args:      []string{"-event.list", "invalid,stuff", "-event.pubsub-topic", "gcs-events", "-event.pubsub-project-id", "test-project"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid log level",
+			args:      []string{"-log-level", "non-existent-level"},
 			expectErr: true,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 		log.Fatal(err)
 	}
 	logger := logrus.New()
+	logger.SetLevel(cfg.LogLevel)
 
 	var emptyBuckets []string
 	opts := cfg.ToFakeGcsOptions()


### PR DESCRIPTION
Addresses #932 

Adds the `-log-level` flag. From my analysis, it seems like there really are only three kinds of logs made by the gcs server:
1. Info logs: Http request logs and some other information logs made by `main.go`
2. Warning logs
3. Error logs

Nonetheless, the user can specify, with a string, one of the 7 accepted levels from the [logrus](https://pkg.go.dev/github.com/sirupsen/logrus) package: fatal, panic, error, warning, info, debug, or trace, and the appropriate log level will be set. 