### PR TITLE
Fix custom-time error

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -42,6 +42,7 @@ type ObjectAttrs struct {
 	Created    time.Time
 	Updated    time.Time
 	Deleted    time.Time
+	CustomTime time.Time
 	Generation int64
 	Metadata   map[string]string
 }
@@ -50,24 +51,27 @@ func (o *ObjectAttrs) id() string {
 	return o.BucketName + "/" + o.Name
 }
 
+type jsonObject struct {
+	BucketName      string            `json:"bucket"`
+	Name            string            `json:"name"`
+	Size            int64             `json:"size,string"`
+	ContentType     string            `json:"contentType"`
+	ContentEncoding string            `json:"contentEncoding"`
+	Crc32c          string            `json:"crc32c,omitempty"`
+	Md5Hash         string            `json:"md5Hash,omitempty"`
+	Etag            string            `json:"etag,omitempty"`
+	ACL             []aclRule         `json:"acl,omitempty"`
+	Created         time.Time         `json:"created,omitempty"`
+	Updated         time.Time         `json:"updated,omitempty"`
+	Deleted         time.Time         `json:"deleted,omitempty"`
+	CustomTime      time.Time         `json:"customTime,omitempty"`
+	Generation      int64             `json:"generation,omitempty,string"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
+}
+
 // MarshalJSON for ObjectAttrs to use ACLRule instead of storage.ACLRule
 func (o ObjectAttrs) MarshalJSON() ([]byte, error) {
-	temp := struct {
-		BucketName      string            `json:"bucket"`
-		Name            string            `json:"name"`
-		Size            int64             `json:"size,string"`
-		ContentType     string            `json:"contentType"`
-		ContentEncoding string            `json:"contentEncoding"`
-		Crc32c          string            `json:"crc32c,omitempty"`
-		Md5Hash         string            `json:"md5Hash,omitempty"`
-		Etag            string            `json:"etag,omitempty"`
-		ACL             []aclRule         `json:"acl,omitempty"`
-		Created         time.Time         `json:"created,omitempty"`
-		Updated         time.Time         `json:"updated,omitempty"`
-		Deleted         time.Time         `json:"deleted,omitempty"`
-		Generation      int64             `json:"generation,omitempty,string"`
-		Metadata        map[string]string `json:"metadata,omitempty"`
-	}{
+	temp := jsonObject{
 		BucketName:      o.BucketName,
 		Name:            o.Name,
 		ContentType:     o.ContentType,
@@ -79,6 +83,7 @@ func (o ObjectAttrs) MarshalJSON() ([]byte, error) {
 		Created:         o.Created,
 		Updated:         o.Updated,
 		Deleted:         o.Deleted,
+		CustomTime:      o.CustomTime,
 		Generation:      o.Generation,
 		Metadata:        o.Metadata,
 	}
@@ -91,22 +96,7 @@ func (o ObjectAttrs) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON for ObjectAttrs to use ACLRule instead of storage.ACLRule
 func (o *ObjectAttrs) UnmarshalJSON(data []byte) error {
-	temp := struct {
-		BucketName      string            `json:"bucket"`
-		Name            string            `json:"name"`
-		Size            int64             `json:"size,string"`
-		ContentType     string            `json:"contentType"`
-		ContentEncoding string            `json:"contentEncoding"`
-		Crc32c          string            `json:"crc32c,omitempty"`
-		Md5Hash         string            `json:"md5Hash,omitempty"`
-		Etag            string            `json:"etag,omitempty"`
-		ACL             []aclRule         `json:"acl,omitempty"`
-		Created         time.Time         `json:"created,omitempty"`
-		Updated         time.Time         `json:"updated,omitempty"`
-		Deleted         time.Time         `json:"deleted,omitempty"`
-		Generation      int64             `json:"generation,omitempty,string"`
-		Metadata        map[string]string `json:"metadata,omitempty"`
-	}{}
+	var temp jsonObject
 	if err := json.Unmarshal(data, &temp); err != nil {
 		return err
 	}
@@ -123,6 +113,7 @@ func (o *ObjectAttrs) UnmarshalJSON(data []byte) error {
 	o.Deleted = temp.Deleted
 	o.Generation = temp.Generation
 	o.Metadata = temp.Metadata
+	o.CustomTime = temp.CustomTime
 	o.ACL = make([]storage.ACLRule, len(temp.ACL))
 	for i, ACL := range temp.ACL {
 		o.ACL[i] = storage.ACLRule(ACL)
@@ -416,6 +407,7 @@ func toBackendObjects(objects []StreamingObject) []backend.StreamingObject {
 				Created:         getCurrentIfZero(o.Created).Format(timestampFormat),
 				Deleted:         o.Deleted.Format(timestampFormat),
 				Updated:         getCurrentIfZero(o.Updated).Format(timestampFormat),
+				CustomTime:      o.CustomTime.Format(timestampFormat),
 				Generation:      o.Generation,
 				Metadata:        o.Metadata,
 			},
@@ -439,6 +431,7 @@ func bufferedObjectsToBackendObjects(objects []Object) []backend.StreamingObject
 				Created:         getCurrentIfZero(o.Created).Format(timestampFormat),
 				Deleted:         o.Deleted.Format(timestampFormat),
 				Updated:         getCurrentIfZero(o.Updated).Format(timestampFormat),
+				CustomTime:      o.CustomTime.Format(timestampFormat),
 				Generation:      o.Generation,
 				Metadata:        o.Metadata,
 			},
@@ -465,6 +458,7 @@ func fromBackendObjects(objects []backend.StreamingObject) []StreamingObject {
 				Created:         convertTimeWithoutError(o.Created),
 				Deleted:         convertTimeWithoutError(o.Deleted),
 				Updated:         convertTimeWithoutError(o.Updated),
+				CustomTime:      convertTimeWithoutError(o.CustomTime),
 				Generation:      o.Generation,
 				Metadata:        o.Metadata,
 			},
@@ -490,6 +484,7 @@ func fromBackendObjectsAttrs(objectAttrs []backend.ObjectAttrs) []ObjectAttrs {
 			Created:         convertTimeWithoutError(o.Created),
 			Deleted:         convertTimeWithoutError(o.Deleted),
 			Updated:         convertTimeWithoutError(o.Updated),
+			CustomTime:      convertTimeWithoutError(o.CustomTime),
 			Generation:      o.Generation,
 			Metadata:        o.Metadata,
 		})
@@ -945,8 +940,9 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	}
 
 	var payload struct {
-		Metadata map[string]string `json:"metadata"`
-		Acl      []acls
+		Metadata   map[string]string `json:"metadata"`
+		CustomTime string
+		Acl        []acls
 	}
 	err := json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
@@ -959,6 +955,7 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	var attrsToUpdate backend.ObjectAttrs
 
 	attrsToUpdate.Metadata = payload.Metadata
+	attrsToUpdate.CustomTime = payload.CustomTime
 
 	if len(payload.Acl) > 0 {
 		attrsToUpdate.ACL = []storage.ACLRule{}
@@ -978,7 +975,8 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	defer backendObj.Close()
 
 	s.eventManager.Trigger(&backendObj, notification.EventMetadata, nil)
-	return jsonResponse{data: fromBackendObjects([]backend.StreamingObject{backendObj})[0]}
+	resp := jsonResponse{data: fromBackendObjects([]backend.StreamingObject{backendObj})[0]}
+	return resp
 }
 
 func (s *Server) updateObject(r *http.Request) jsonResponse {

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -109,6 +109,7 @@ type objectResponse struct {
 	TimeDeleted     string                 `json:"timeDeleted,omitempty"`
 	Updated         string                 `json:"updated,omitempty"`
 	Generation      int64                  `json:"generation,string"`
+	CustomTime      string                 `json:"customTime,omitempty"`
 	Metadata        map[string]string      `json:"metadata,omitempty"`
 }
 
@@ -131,6 +132,7 @@ func newObjectResponse(obj ObjectAttrs) objectResponse {
 		TimeCreated:     formatTime(obj.Created),
 		TimeDeleted:     formatTime(obj.Deleted),
 		Updated:         formatTime(obj.Updated),
+		CustomTime:      formatTime(obj.CustomTime),
 		Generation:      obj.Generation,
 	}
 }

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -28,6 +28,7 @@ type ObjectAttrs struct {
 	Created         string
 	Deleted         string
 	Updated         string
+	CustomTime      string
 	Generation      int64
 }
 


### PR DESCRIPTION
Fixes https://github.com/fsouza/fake-gcs-server/issues/410.

If I now run the following python script:

```
self.client = storage.Client()
self.bucket = self.client.get_bucket(bucket_name)

blob = self.bucket.blob(blob_name)
blob.upload_from_string(value, content_type=content_type)
blob.reload()
blob.custom_time = datetime.datetime.now(datetime.timezone.utc)
blob.patch()
blob = self.bucket.get_blob(blob_name)
print(blob.custom_time)
```

It now does not print `None` but rather prints the correct time.

Let me know if there is anything I should change or add. One thing I was unsure of is that in `fakestorage/object.go`, I did not make any changes to `UpdateObject`, so it still only updates metadata rather than any other attributes like `CustomTime` or `Acl` (unlike the `PatchObject` method). Let me know if `UpdateObject` should be similarly changed.