### PR TITLE
A quick fix for enviroment variables config support when running in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go build -o fake-gcs-server
 FROM alpine:3.17.1
 RUN apk add --no-cache mailcap
 COPY --from=builder /code/fake-gcs-server /bin/fake-gcs-server
+COPY --from=builder /code/run.sh /run.sh
 RUN /bin/fake-gcs-server -h
 EXPOSE 4443
-ENTRYPOINT ["/bin/fake-gcs-server", "-data", "/data"]
+ENTRYPOINT "/run.sh"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ instructions
 docker run --rm fsouza/fake-gcs-server -help
 ```
 
+### Using environment variables
+
+The docker image supports using environmental variables when starting fake-gcs-server.
+
+```shell
+docker run -d --name fake-gcs-server -e SCHEME=http -e PORT=8080 -p 8080:8080 fsouza/fake-gcs-server
+```
+
+
 ## Client library examples
 
 For examples using SDK from multiple languages, check out the

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+/bin/fake-gcs-server \
+  -backend "${BACKEND:-filesystem}" \
+  -cert-location "${CERT_LOCATION}" \
+  -cors-headers "${CORS_HEADERS}" \
+  -data "${DATA:-/data}" \
+  -event.list "${EVENT_LIST:-finalize}" \
+  -event.object-prefix "${EVENT_OBJECT_PREFIX}" \
+  -event.pubsub-project-id "${EVENT_PUBSUB_PROJECT_ID}" \
+  -event.pubsub-topic "${EVENT_PUBSUB_TOPIC}" \
+  -external-url "${EXTERNAL_URL}" \
+  -filesystem-root "${FILESYSTEM_ROOT:-/storage}" \
+  -host "${HOST:-0.0.0.0}" \
+  -location "${LOCATION:-US-CENTRAL1}" \
+  -log-level "${LOG_LEVEL:-info}" \
+  -port "${PORT:-4443}" \
+  -private-key-location "${PRIVATE_KEY_LOCATION}" \
+  -public-host "${PUBLIC_HOST:-storage.googleapis.com}" \
+  -scheme "${SCHEME:-https}"


### PR DESCRIPTION
Hey, 

This partially fixes #561 so that the project can be used in GitHub actions. I will look into using the env vars as a build in thing, because now there's an overlap of default values.
