### PR TITLE
supportsuccess_action_status form field for HTML form uploads

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -123,6 +123,17 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 	if contentTypes, ok := r.MultipartForm.Value["Content-Type"]; ok {
 		contentType = contentTypes[0]
 	}
+	var successActionStatus int = http.StatusNoContent
+	if successActionStatuses, ok := r.MultipartForm.Value["success_action_status"]; ok {
+		successInt, err := strconv.Atoi(successActionStatuses[0])
+		if err != nil {
+			return xmlResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
+		}
+		if successInt != http.StatusOK && successInt != http.StatusCreated && successInt != http.StatusNoContent {
+			return xmlResponse{errorMessage: "invalid success action status", status: http.StatusBadRequest}
+		}
+		successActionStatus = successInt
+	}
 	metaData := make(map[string]string)
 	for key := range r.MultipartForm.Value {
 		lowerKey := strings.ToLower(key)
@@ -159,7 +170,7 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 		return xmlResponse{errorMessage: err.Error()}
 	}
 	defer obj.Close()
-	return xmlResponse{status: http.StatusNoContent}
+	return xmlResponse{status: successActionStatus}
 }
 
 func (s *Server) wrapUploadPreconditions(r *http.Request, bucketName string, objectName string) (generationCondition, error) {

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -123,7 +123,7 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 	if contentTypes, ok := r.MultipartForm.Value["Content-Type"]; ok {
 		contentType = contentTypes[0]
 	}
-	var successActionStatus int = http.StatusNoContent
+	successActionStatus := http.StatusNoContent
 	if successActionStatuses, ok := r.MultipartForm.Value["success_action_status"]; ok {
 		successInt, err := strconv.Atoi(successActionStatuses[0])
 		if err != nil {
@@ -170,6 +170,12 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 		return xmlResponse{errorMessage: err.Error()}
 	}
 	defer obj.Close()
+
+	if successActionStatus == 201 {
+		objectURI := fmt.Sprintf("%s/%s%s", s.URL(), bucketName, name)
+		xmlBody := createXmlResponseBody(bucketName, obj.Etag, strings.TrimPrefix(name, "/"), objectURI)
+		return xmlResponse{status: successActionStatus, data: xmlBody}
+	}
 	return xmlResponse{status: successActionStatus}
 }
 

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -923,7 +923,7 @@ func TestFormDataUpload(t *testing.T) {
 	var buf bytes.Buffer
 	const content = "some weird content"
 	const contentType = "text/plain"
-	var successActionStatus int = http.StatusNoContent
+	successActionStatus := http.StatusNoContent
 	writer := multipart.NewWriter(&buf)
 
 	var fieldWriter io.Writer

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -922,6 +923,7 @@ func TestFormDataUpload(t *testing.T) {
 	var buf bytes.Buffer
 	const content = "some weird content"
 	const contentType = "text/plain"
+	var successActionStatus int = http.StatusNoContent
 	writer := multipart.NewWriter(&buf)
 
 	var fieldWriter io.Writer
@@ -936,6 +938,13 @@ func TestFormDataUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := fieldWriter.Write([]byte(contentType)); err != nil {
+		t.Fatal(err)
+	}
+
+	if fieldWriter, err = writer.CreateFormField("success_action_status"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fieldWriter.Write([]byte(strconv.Itoa(successActionStatus))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -974,9 +983,8 @@ func TestFormDataUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	expectedStatus := http.StatusNoContent
-	if resp.StatusCode != expectedStatus {
-		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
+	if resp.StatusCode != successActionStatus {
+		t.Errorf("wrong status code\nwant %d\ngot  %d", successActionStatus, resp.StatusCode)
 	}
 
 	obj, err := server.GetObject("other-bucket", "object.txt")

--- a/fakestorage/xml_response.go
+++ b/fakestorage/xml_response.go
@@ -12,6 +12,14 @@ type xmlResponse struct {
 	errorMessage string
 }
 
+type xmlResponseBody struct {
+	XMLName  xml.Name `xml:"PostResponse"`
+	Bucket   string
+	Etag     interface{}
+	Key      string
+	Location string
+}
+
 type xmlHandler = func(r *http.Request) xmlResponse
 
 func xmlToHTTPHandler(h xmlHandler) http.HandlerFunc {
@@ -33,8 +41,30 @@ func xmlToHTTPHandler(h xmlHandler) http.HandlerFunc {
 		}
 
 		w.WriteHeader(status)
-		xml.NewEncoder(w).Encode(data)
+		if status == 201 {
+			dataBytes, _ := data.([]byte)
+			w.Write(dataBytes)
+		} else {
+			xml.NewEncoder(w).Encode(data)
+		}
 	}
+}
+
+func createXmlResponseBody(bucketName, etag, key, location string) []byte {
+	responseBody := xmlResponseBody{
+		Bucket: bucketName,
+		Etag: struct {
+			Value string `xml:",innerxml"`
+		}{etag},
+		Location: location,
+		Key:      key,
+	}
+	x, err := xml.Marshal(responseBody)
+	if err != nil {
+		return nil
+	}
+
+	return []byte(xml.Header + string(x))
 }
 
 func (r *xmlResponse) getStatus() int {

--- a/fakestorage/xml_response.go
+++ b/fakestorage/xml_response.go
@@ -13,9 +13,11 @@ type xmlResponse struct {
 }
 
 type xmlResponseBody struct {
-	XMLName  xml.Name `xml:"PostResponse"`
-	Bucket   string
-	Etag     interface{}
+	XMLName xml.Name `xml:"PostResponse"`
+	Bucket  string
+	Etag    struct {
+		Value string `xml:",innerxml"`
+	}
 	Key      string
 	Location string
 }


### PR DESCRIPTION
When uploading an object with a HTML form, the GCS XML api allows us to set a `success_action_status`: [Upload an object with a HTML form](https://cloud.google.com/storage/docs/xml-api/post-object-forms#:~:text=No-,success_action_status,-The%20status%20code)

> The status code that you want Cloud Storage to respond with when an upload is successful. The default is 204, but you can change this to 200 or 201

Presently `fake-gcs-server` ignores this and responds with the default status code 204 (https://github.com/fsouza/fake-gcs-server/blob/main/fakestorage/upload.go#L162)

This PR allows us to specify a preferred return value of 200, 201 or 204.