### PR TITLE
Use `any` instead of `interface{}`

### DIFF
--- a/fakestorage/json_response.go
+++ b/fakestorage/json_response.go
@@ -13,7 +13,7 @@ import (
 type jsonResponse struct {
 	status       int
 	header       http.Header
-	data         interface{}
+	data         any
 	errorMessage string
 }
 
@@ -30,7 +30,7 @@ func jsonToHTTPHandler(h jsonHandler) http.HandlerFunc {
 		}
 
 		status := resp.getStatus()
-		var data interface{}
+		var data any
 		if status > 399 {
 			data = newErrorResponse(status, resp.getErrorMessage(status), nil)
 		} else {

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -20,15 +20,15 @@ func formatTime(t time.Time) string {
 }
 
 type listResponse struct {
-	Kind     string        `json:"kind"`
-	Items    []interface{} `json:"items"`
-	Prefixes []string      `json:"prefixes,omitempty"`
+	Kind     string   `json:"kind"`
+	Items    []any    `json:"items"`
+	Prefixes []string `json:"prefixes,omitempty"`
 }
 
 func newListBucketsResponse(buckets []backend.Bucket, location string) listResponse {
 	resp := listResponse{
 		Kind:  "storage#buckets",
-		Items: make([]interface{}, len(buckets)),
+		Items: make([]any, len(buckets)),
 	}
 	for i, bucket := range buckets {
 		resp.Items[i] = newBucketResponse(bucket, location)
@@ -63,7 +63,7 @@ func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {
 func newListObjectsResponse(objs []ObjectAttrs, prefixes []string) listResponse {
 	resp := listResponse{
 		Kind:     "storage#objects",
-		Items:    make([]interface{}, len(objs)),
+		Items:    make([]any, len(objs)),
 		Prefixes: prefixes,
 	}
 	for i, obj := range objs {

--- a/fakestorage/xml_response.go
+++ b/fakestorage/xml_response.go
@@ -8,7 +8,7 @@ import (
 type xmlResponse struct {
 	status       int
 	header       http.Header
-	data         interface{}
+	data         any
 	errorMessage string
 }
 
@@ -25,7 +25,7 @@ func xmlToHTTPHandler(h xmlHandler) http.HandlerFunc {
 		}
 
 		status := resp.getStatus()
-		var data interface{}
+		var data any
 		if status > 399 {
 			data = newErrorResponse(status, resp.getErrorMessage(status), nil)
 		} else {


### PR DESCRIPTION
I meant to do this when Go 1.19 was released, but I got distracted. Now Go 1.20 is around the corner, so let's get rolling with this.