### PR TITLE
Use Go 1.20 in CI

### DIFF
--- a/.github/workflows/goreleaser-run.yml
+++ b/.github/workflows/goreleaser-run.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - uses: goreleaser/goreleaser-action@v4.2.0
         env:

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - uses: goreleaser/goreleaser-action@v4.2.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - 1.18
           - 1.19
+          - "1.20"
         os:
           - macos
           - ubuntu
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-go@v3.5.0
         id: go
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - run: |
           go install honnef.co/go/tools/cmd/staticcheck@master
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-go@v3.5.0
         id: go
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: go-build
         run: go build -o fake-gcs-server

--- a/go.mod
+++ b/go.mod
@@ -41,4 +41,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.19


### PR DESCRIPTION
Also set the minimum version in go.mod to Go 1.19 now that Go 1.18 is unsupported. Dependabot will take care of the Dockerfile.