### PR TITLE
backend: make sure we have the right info for transcoded objects

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -434,6 +434,10 @@ func bufferedObjectsToBackendObjects(objects []Object) []backend.StreamingObject
 				CustomTime:      o.CustomTime.Format(timestampFormat),
 				Generation:      o.Generation,
 				Metadata:        o.Metadata,
+				Crc32c:          o.Crc32c,
+				Md5Hash:         o.Md5Hash,
+				Size:            o.Size,
+				Etag:            o.Etag,
 			},
 			Content: o.Content,
 		})

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -391,6 +391,7 @@ func TestServerClientObjectTranscoding(t *testing.T) {
 				Name:            objectName,
 				ContentType:     contentType,
 				ContentEncoding: contentEncoding,
+				Crc32c:          checksum.EncodedCrc32cChecksum([]byte(content)),
 			},
 			Content: b.Bytes(),
 		},

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -198,9 +198,15 @@ func (s *storageFS) CreateObject(obj StreamingObject, conditions Conditions) (St
 		return StreamingObject{}, err
 	}
 
-	obj.Crc32c = hasher.EncodedCrc32cChecksum()
-	obj.Md5Hash = hasher.EncodedMd5Hash()
-	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+	if obj.Crc32c == "" {
+		obj.Crc32c = hasher.EncodedCrc32cChecksum()
+	}
+	if obj.Md5Hash == "" {
+		obj.Md5Hash = hasher.EncodedMd5Hash()
+	}
+	if obj.Etag == "" {
+		obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+	}
 
 	// TODO: Handle if metadata is not present more gracefully?
 	encoded, err := json.Marshal(obj.ObjectAttrs)

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -37,10 +37,18 @@ func newBucketInMemory(name string, versioningEnabled bool) bucketInMemory {
 }
 
 func (bm *bucketInMemory) addObject(obj Object) Object {
-	obj.Crc32c = checksum.EncodedCrc32cChecksum(obj.Content)
-	obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
-	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
-	obj.Size = int64(len(obj.Content))
+	if obj.Crc32c == "" {
+		obj.Crc32c = checksum.EncodedCrc32cChecksum(obj.Content)
+	}
+	if obj.Md5Hash == "" {
+		obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
+	}
+	if obj.Etag == "" {
+		obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+	}
+	if obj.Size == 0 {
+		obj.Size = int64(len(obj.Content))
+	}
 	obj.Generation = getNewGenerationIfZero(obj.Generation)
 	index := findObject(obj, bm.activeObjects, false)
 	if index >= 0 {
@@ -358,9 +366,10 @@ func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, d
 	}
 
 	dest.Content = data
-	dest.Crc32c = checksum.EncodedCrc32cChecksum(data)
-	dest.Md5Hash = checksum.EncodedMd5Hash(data)
-	dest.Etag = fmt.Sprintf("%q", dest.Md5Hash)
+	dest.Crc32c = ""
+	dest.Md5Hash = ""
+	dest.Etag = ""
+	dest.Size = 0
 	dest.Metadata = metadata
 
 	result, err := s.CreateObject(dest.StreamingObject(), NoConditions{})


### PR DESCRIPTION
This is a bug exposed by an upgrade of the Go SDK (see #1100). Hopefully this doesn't break other SDKs.