### PR TITLE
Fix directory being used during reseed

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -77,6 +77,7 @@ func NewServerWithHostPort(objects []Object, host string, port uint16) (*Server,
 type Options struct {
 	InitialObjects []Object
 	StorageRoot    string
+	Seed           string
 	Scheme         string
 	Host           string
 	Port           uint16
@@ -292,8 +293,7 @@ func (s *Server) buildMuxer() {
 }
 
 func (s *Server) reseedServer(r *http.Request) jsonResponse {
-	folder := "/data"
-	initialObjects, emptyBuckets := generateObjectsFromFiles(folder)
+	initialObjects, emptyBuckets := generateObjectsFromFiles(s.options.Seed)
 
 	backendObjects := bufferedObjectsToBackendObjects(initialObjects)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,7 @@ func (c *Config) ToFakeGcsOptions() fakestorage.Options {
 	logger.SetLevel(c.LogLevel)
 	opts := fakestorage.Options{
 		StorageRoot:         storageRoot,
+		Seed:                c.Seed,
 		Scheme:              c.scheme,
 		Host:                c.host,
 		Port:                uint16(c.port),


### PR DESCRIPTION
Related to #1079.

"/data" directory was hard-coded previously, needed to use config's "Seed" instead.
E.g. when running it like this:
`docker run -d -p 4444:4443 -v ~/test_data:/store fsouza/fake-gcs-server -data "/store"`
the files were being loaded from "/data" and not from `/store`.