### PR TITLE
Propagate ContentType field on create/modify ops

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -993,9 +993,10 @@ func (s *Server) updateObject(r *http.Request) jsonResponse {
 	}
 
 	var payload struct {
-		Metadata   map[string]string `json:"metadata"`
-		CustomTime string
-		Acl        []acls
+		Metadata    map[string]string `json:"metadata"`
+		ContentType string            `json:"contentType"`
+		CustomTime  string
+		Acl         []acls
 	}
 	err := json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
@@ -1009,7 +1010,7 @@ func (s *Server) updateObject(r *http.Request) jsonResponse {
 
 	attrsToUpdate.Metadata = payload.Metadata
 	attrsToUpdate.CustomTime = payload.CustomTime
-
+	attrsToUpdate.ContentType = payload.ContentType
 	if len(payload.Acl) > 0 {
 		attrsToUpdate.ACL = []storage.ACLRule{}
 		for _, aclData := range payload.Acl {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1712,8 +1712,8 @@ func TestServerClientObjectUpdateContentType(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		var updatedContentType string = respJsonBody.ContentType
-		var expectedContentType string = "another content-type"
+		updatedContentType := respJsonBody.ContentType
+		expectedContentType := "another content-type"
 		if updatedContentType != expectedContentType {
 			t.Errorf("unexpected content type time\nwant %q\ngot  %q", expectedContentType, updatedContentType)
 		}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -485,7 +485,12 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	obj.Crc32c = checksum.EncodedCrc32cChecksum(obj.Content)
 	obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
 	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
-	obj.ContentType = r.Header.Get(contentTypeHeader)
+	contentTypeHeader := r.Header.Get(contentTypeHeader)
+	if contentTypeHeader != "" {
+		obj.ContentType = contentTypeHeader
+	} else {
+		obj.ContentType = "application/octet-stream"
+	}
 	responseHeader := make(http.Header)
 	if contentRange := r.Header.Get("Content-Range"); contentRange != "" {
 		parsed, err := parseContentRange(contentRange)


### PR DESCRIPTION
This PR tries to address 2 bugs that where found when using some of the create/modify operations GCS supports in our integration tests that used the following interactions:
* Rely on a streamable upload operations of GCS to upload of a File.
* Submit an update on the blob to override the metadata content-type information without modifying the bytes of the blob.

To crosscheck, we ran the same tests against the real GCS API to verify the behaviour to expect:
1. Streamable upload, by default if no `content-type `is provided; GCS sets it up to` 'application/octet-stream'` or uses the one provided by the user in the BlobInfo (This is the expected behaviour for this operation in GCS).
2. For an update, when we merge metadata information regarding the content-type, it should override and reflect the change on the update response.

Also this behaviour is referenced on the API spec, that the `content-type` should be set to `application/octet-stream` on object creation if it is not defined:

1. [GCS Insert Request Body](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body)
2. [GCS Update Request Body](https://cloud.google.com/storage/docs/json_api/v1/objects/update#request-body)

Also should hopefully address the following issue https://github.com/fsouza/fake-gcs-server/issues/1098 :slightly_smiling_face: 

Fixes #1098.