### PR TITLE
fakestorage: don't expose the Backend field

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -24,7 +24,7 @@ var bucketRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
 //
 // Deprecated: use CreateBucketWithOpts.
 func (s *Server) CreateBucket(name string) {
-	err := s.Backend.CreateBucket(name, false)
+	err := s.backend.CreateBucket(name, false)
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ type CreateBucketOpts struct {
 //
 // If the underlying backend returns an error, this method panics.
 func (s *Server) CreateBucketWithOpts(opts CreateBucketOpts) {
-	err := s.Backend.CreateBucket(opts.Name, opts.VersioningEnabled)
+	err := s.backend.CreateBucket(opts.Name, opts.VersioningEnabled)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +71,7 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 		return jsonResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
 	}
 
-	_, err := s.Backend.GetBucket(name)
+	_, err := s.backend.GetBucket(name)
 	if err == nil {
 		return jsonResponse{
 			errorMessage: fmt.Sprintf(
@@ -84,12 +84,12 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 	}
 
 	// Create the named bucket
-	if err := s.Backend.CreateBucket(name, versioning); err != nil {
+	if err := s.backend.CreateBucket(name, versioning); err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
 
 	// Return the created bucket:
-	bucket, err := s.Backend.GetBucket(name)
+	bucket, err := s.backend.GetBucket(name)
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
@@ -97,7 +97,7 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 }
 
 func (s *Server) listBuckets(r *http.Request) jsonResponse {
-	buckets, err := s.Backend.ListBuckets()
+	buckets, err := s.backend.ListBuckets()
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
@@ -106,7 +106,7 @@ func (s *Server) listBuckets(r *http.Request) jsonResponse {
 
 func (s *Server) getBucket(r *http.Request) jsonResponse {
 	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
-	bucket, err := s.Backend.GetBucket(bucketName)
+	bucket, err := s.backend.GetBucket(bucketName)
 	if err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
@@ -115,7 +115,7 @@ func (s *Server) getBucket(r *http.Request) jsonResponse {
 
 func (s *Server) deleteBucket(r *http.Request) jsonResponse {
 	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
-	err := s.Backend.DeleteBucket(bucketName)
+	err := s.backend.DeleteBucket(bucketName)
 	if err == backend.BucketNotFound {
 		return jsonResponse{status: http.StatusNotFound}
 	}

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -42,7 +42,7 @@ const defaultPublicHost = "storage.googleapis.com"
 //
 // It provides a fake implementation of the Google Cloud Storage API.
 type Server struct {
-	Backend      backend.Storage
+	backend      backend.Storage
 	uploads      sync.Map
 	transport    http.RoundTripper
 	ts           *httptest.Server
@@ -211,7 +211,7 @@ func newServer(options Options) (*Server, error) {
 	}
 
 	s := Server{
-		Backend:      backendStorage,
+		backend:      backendStorage,
 		uploads:      sync.Map{},
 		externalURL:  options.ExternalURL,
 		publicHost:   publicHost,
@@ -313,9 +313,9 @@ func (s *Server) reseedServer(r *http.Request) jsonResponse {
 
 	var err error
 	if s.options.StorageRoot != "" {
-		s.Backend, err = backend.NewStorageFS(backendObjects, s.options.StorageRoot)
+		s.backend, err = backend.NewStorageFS(backendObjects, s.options.StorageRoot)
 	} else {
-		s.Backend, err = backend.NewStorageMemory(backendObjects)
+		s.backend, err = backend.NewStorageMemory(backendObjects)
 	}
 	if err != nil {
 		return errToJsonResponse(err)
@@ -423,6 +423,10 @@ func (s *Server) URL() string {
 // PublicURL returns the server's public download URL.
 func (s *Server) PublicURL() string {
 	return fmt.Sprintf("%s://%s", s.scheme(), s.publicHost)
+}
+
+func (s *Server) Backend() backend.Storage {
+	return s.backend
 }
 
 func (s *Server) scheme() string {

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -1012,7 +1012,7 @@ func TestServerEventNotification(t *testing.T) {
 			}
 			eventManager := &fakeEventManager{}
 			server.eventManager = eventManager
-			err = server.Backend.CreateBucket(obj.BucketName, test.versioningEnabled)
+			err = server.backend.CreateBucket(obj.BucketName, test.versioningEnabled)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1051,7 +1051,7 @@ func TestServerBatchRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = server.Backend.CreateBucket("some-bucket", true)
+	err = server.backend.CreateBucket("some-bucket", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -67,7 +67,7 @@ func (c generationCondition) ConditionsMet(activeGeneration int64) bool {
 func (s *Server) insertObject(r *http.Request) jsonResponse {
 	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
 
-	if _, err := s.Backend.GetBucket(bucketName); err != nil {
+	if _, err := s.backend.GetBucket(bucketName); err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
 	uploadType := r.URL.Query().Get("uploadType")

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	go func() {
-		err := grpc.NewServerWithBackend(server.Backend, grpcListener)
+		err := grpc.NewServerWithBackend(server.Backend(), grpcListener)
 		println("Error while starting grpc server: ", err)
 	}()
 


### PR DESCRIPTION
Make it available via a method instead. This way at least the reference is readonly.

Technically a breaking change, but it's short-lived :)