### PR TITLE
Add bucket filter for notification events

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 type EventConfig struct {
 	pubsubProjectID string
 	pubsubTopic     string
+	bucket          string
 	prefix          string
 	list            []string
 }
@@ -71,6 +72,7 @@ func Load(args []string) (Config, error) {
 	fs.UintVar(&cfg.Port, "port", 4443, "port to bind to")
 	fs.StringVar(&cfg.event.pubsubProjectID, "event.pubsub-project-id", "", "project ID containing the pubsub topic")
 	fs.StringVar(&cfg.event.pubsubTopic, "event.pubsub-topic", "", "pubsub topic name to publish events on")
+	fs.StringVar(&cfg.event.bucket, "event.bucket", "", "if not empty, only objects in this bucket will generate trigger events")
 	fs.StringVar(&cfg.event.prefix, "event.object-prefix", "", "if not empty, only objects having this prefix will generate trigger events")
 	fs.StringVar(&eventList, "event.list", eventFinalize, "comma separated list of events to publish on cloud function URl. Options are: finalize, delete, and metadataUpdate")
 	fs.StringVar(&cfg.bucketLocation, "location", "US-CENTRAL1", "location for buckets")
@@ -150,6 +152,7 @@ func (c *Config) ToFakeGcsOptions() fakestorage.Options {
 	eventOptions := notification.EventManagerOptions{
 		ProjectID:    c.event.pubsubProjectID,
 		TopicName:    c.event.pubsubTopic,
+		Bucket:       c.event.bucket,
 		ObjectPrefix: c.event.prefix,
 	}
 	if c.event.pubsubProjectID != "" && c.event.pubsubTopic != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,6 +157,7 @@ func TestToFakeGcsOptions(t *testing.T) {
 				event: EventConfig{
 					pubsubProjectID: "test-project",
 					pubsubTopic:     "gcs-events",
+					bucket:          "my-bucket",
 					prefix:          "uploads/",
 					list:            []string{"finalize", "delete"},
 				},
@@ -171,6 +172,7 @@ func TestToFakeGcsOptions(t *testing.T) {
 				EventOptions: notification.EventManagerOptions{
 					ProjectID:    "test-project",
 					TopicName:    "gcs-events",
+					Bucket:       "my-bucket",
 					ObjectPrefix: "uploads/",
 					NotifyOn: notification.EventNotificationOptions{
 						Finalize:       true,

--- a/internal/notification/event.go
+++ b/internal/notification/event.go
@@ -44,6 +44,8 @@ type EventManagerOptions struct {
 	ProjectID string
 	// TopicName is the pubsub topic name to publish events on.
 	TopicName string
+	// Bucket is the name of the bucket to publish events from.
+	Bucket string
 	// ObjectPrefix, if not empty, only objects having this prefix will generate
 	// trigger events.
 	ObjectPrefix string
@@ -65,6 +67,8 @@ type PubsubEventManager struct {
 	notifyOn EventNotificationOptions
 	// writer is where logs are written to.
 	writer io.Writer
+	// bucket, if not empty, only objects from this bucker will generate trigger events.
+	bucket string
 	// objectPrefix, if not empty, only objects having this prefix will generate
 	// trigger events.
 	objectPrefix string
@@ -76,6 +80,7 @@ func NewPubsubEventManager(options EventManagerOptions, w io.Writer) (*PubsubEve
 	manager := &PubsubEventManager{
 		writer:       w,
 		notifyOn:     options.NotifyOn,
+		bucket:       options.Bucket,
 		objectPrefix: options.ObjectPrefix,
 	}
 	if options.ProjectID != "" && options.TopicName != "" {
@@ -98,6 +103,9 @@ type eventPublisher interface {
 // event to a pubsub queue.
 func (m *PubsubEventManager) Trigger(o *backend.StreamingObject, eventType EventType, extraEventAttr map[string]string) {
 	if m.publisher == nil {
+		return
+	}
+	if m.bucket != "" && o.BucketName != m.bucket {
 		return
 	}
 	if m.objectPrefix != "" && !strings.HasPrefix(o.Name, m.objectPrefix) {

--- a/internal/notification/event_test.go
+++ b/internal/notification/event_test.go
@@ -34,6 +34,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 		name      string
 		notifyOn  EventNotificationOptions
 		eventType string
+		bucket    string
 		prefix    string
 		metadata  map[string]string
 	}{
@@ -41,6 +42,37 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 			"None",
 			EventNotificationOptions{},
 			"",
+			"",
+			"",
+			nil,
+		},
+		{
+			"Finalize enabled, no bucket",
+			EventNotificationOptions{
+				Finalize: true,
+			},
+			string(EventFinalize),
+			"",
+			"",
+			nil,
+		},
+		{
+			"Finalize enabled, matching bucket",
+			EventNotificationOptions{
+				Finalize: true,
+			},
+			string(EventFinalize),
+			"some-bucket",
+			"",
+			nil,
+		},
+		{
+			"Finalize enabled, non-matching bucket",
+			EventNotificationOptions{
+				Finalize: true,
+			},
+			"",
+			"some-unmatched-bucket",
 			"",
 			nil,
 		},
@@ -51,6 +83,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 			},
 			string(EventFinalize),
 			"",
+			"",
 			nil,
 		},
 		{
@@ -59,6 +92,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 				Finalize: true,
 			},
 			string(EventFinalize),
+			"",
 			"files/",
 			nil,
 		},
@@ -67,6 +101,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 			EventNotificationOptions{
 				Finalize: true,
 			},
+			"",
 			"",
 			"uploads/",
 			nil,
@@ -78,6 +113,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 			},
 			string(EventDelete),
 			"",
+			"",
 			nil,
 		},
 		{
@@ -86,6 +122,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 				MetadataUpdate: true,
 			},
 			string(EventMetadata),
+			"",
 			"",
 			newMetadata,
 		},
@@ -107,6 +144,7 @@ func TestPubsubEventManager_Trigger(t *testing.T) {
 			obj := bufferedObj.StreamingObject()
 			eventManager := PubsubEventManager{
 				notifyOn:     test.notifyOn,
+				bucket:       test.bucket,
 				objectPrefix: test.prefix,
 			}
 			publisher := &mockPublisher{}


### PR DESCRIPTION
Thanks for this project! 

I found the current object level filter for bucket notifications insufficient for my usage.

This PR extends the notification event config to accept a bucket filter. I could change this to accept a CSV of bucket names instead, and would be happy to do so if you thought that would be better. Left it simple to start.