### PR TITLE
Migrate from logrus to slog

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/fsouza/fake-gcs-server/internal/notification"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -542,7 +541,6 @@ func (s *Server) handleBatchCall(w http.ResponseWriter, r *http.Request) {
 
 	_, err = b.WriteTo(w)
 	if err != nil {
-		logrus.New().Error(err)
 		http.Error(w, "unable to process request", http.StatusBadRequest)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/fsouza/fake-gcs-server
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	cloud.google.com/go/storage v1.31.0
+	github.com/fsouza/slognil v0.3.1
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/minio/minio-go/v7 v7.0.61
 	github.com/pkg/xattr v0.4.9
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
 	golang.org/x/oauth2 v0.11.0
 	google.golang.org/api v0.135.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130
@@ -27,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/rs/xid v1.5.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230726155614-23370e0ffb3e // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
@@ -58,4 +60,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.20
+go 1.21

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/iam v1.1.1 h1:lW7fzj15aVIXYHREOqjRBV9PsH0Z6u8Y46a1YGvQP4Y=
 cloud.google.com/go/iam v1.1.1/go.mod h1:A5avdyVL2tCppe4unb0951eI9jreack+RJ0/d+KUZOU=
 cloud.google.com/go/kms v1.12.1 h1:xZmZuwy2cwzsocmKDOPu4BL7umg8QXagQx6fKVmf45U=
+cloud.google.com/go/kms v1.12.1/go.mod h1:c9J991h5DTl+kg7gi3MYomh12YEENGrf48ee/N/2CDM=
 cloud.google.com/go/pubsub v1.33.0 h1:6SPCPvWav64tj0sVX/+npCBKhUi/UjJehy9op/V3p2g=
 cloud.google.com/go/pubsub v1.33.0/go.mod h1:f+w71I33OMyxf9VpMVcZbnG5KSUkCOUHYpFd5U1GdRc=
 cloud.google.com/go/storage v1.31.0 h1:+S3LjjEN2zZ+L5hOwj4+1OkGCsLVe0NzpXKQ1pSdTCI=
@@ -38,6 +39,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsouza/slognil v0.3.1 h1:DYOlyYPFa8lRuriJ3atZnhn+NpGA/rMzkvO970oQEcg=
+github.com/fsouza/slognil v0.3.1/go.mod h1:Q8sD2VtWIDCZxQCLRKFwfRYu5/jU5pqplclsz4fQKF4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -71,6 +74,7 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
@@ -137,6 +141,8 @@ golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230807204917-050eac23e9de h1:l5Za6utMv/HsBWWqzt4S8X17j+kt1uVETUX5UFhn2rE=
+golang.org/x/exp v0.0.0-20230807204917-050eac23e9de/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/fsouza/fake-gcs-server/internal/notification"
+	"github.com/fsouza/slognil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slog"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -60,7 +61,7 @@ func TestLoadConfig(t *testing.T) {
 					list:            []string{"finalize", "delete", "metadataUpdate", "archive"},
 				},
 				bucketLocation: "US-EAST1",
-				LogLevel:       logrus.WarnLevel,
+				LogLevel:       slog.LevelWarn,
 			},
 		},
 		{
@@ -80,7 +81,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -103,7 +104,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -126,7 +127,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -150,7 +151,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -174,7 +175,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -197,7 +198,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -221,7 +222,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -245,7 +246,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -270,7 +271,7 @@ func TestLoadConfig(t *testing.T) {
 					list: []string{"finalize"},
 				},
 				bucketLocation: "US-CENTRAL1",
-				LogLevel:       logrus.InfoLevel,
+				LogLevel:       slog.LevelInfo,
 			},
 		},
 		{
@@ -421,7 +422,7 @@ func TestToFakeGcsOptions(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			opts := test.config.ToFakeGcsOptions(test.config.Scheme)
+			opts := test.config.ToFakeGcsOptions(slognil.NewLogger(), test.config.Scheme)
 			ignWriter := cmpopts.IgnoreFields(fakestorage.Options{}, "Writer")
 			if diff := cmp.Diff(opts, test.expected, ignWriter); diff != "" {
 				t.Errorf("wrong set of options returned\nwant %#v\ngot  %#v\ndiff: %v", test.expected, opts, diff)

--- a/internal/config/slog_writer.go
+++ b/internal/config/slog_writer.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"context"
+
+	"golang.org/x/exp/slog"
+)
+
+type slogWriter struct {
+	logger *slog.Logger
+	level  slog.Level
+}
+
+func (w *slogWriter) Write(p []byte) (n int, err error) {
+	w.logger.Log(context.Background(), w.level, string(p))
+	return len(p), nil
+}


### PR DESCRIPTION
Opening this PR for posteriority, slog doesn't support Go 1.19.