### PR TITLE
multipart uploads: Hack to support gsutil cp

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -315,7 +315,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 	// If we see a string like "boundary='=", which is always invalid anyway,
 	// attempt to rescue the situation by converting all ' to ".
 	if strings.Contains(requestContentType, "boundary='=") {
-		requestContentType = strings.ReplaceAll(requestContentType, "'", "\"")
+		requestContentType = strings.ReplaceAll(requestContentType, "'", `"`)
 	}
 	_, params, err := mime.ParseMediaType(requestContentType)
 	if err != nil {

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -306,7 +306,18 @@ func getObjectACL(predefinedACL string) []storage.ACLRule {
 
 func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonResponse {
 	defer r.Body.Close()
-	_, params, err := mime.ParseMediaType(r.Header.Get(contentTypeHeader))
+	requestContentType := r.Header.Get(contentTypeHeader)
+	// gsutil is observed to submit incorrectly-quoted bounary strings
+	// like: boundary='===============5900997287163282353=='
+	// See https://github.com/GoogleCloudPlatform/gsutil/issues/1466
+	// Having an "=" character in the boundary param requires the value be quoted,
+	// but ' is not a quote char, " is.
+	// If we see a string like "boundary='=", which is always invalid anyway,
+	// attempt to rescue the situation by converting all ' to ".
+	if strings.Contains(requestContentType, "boundary='=") {
+		requestContentType = strings.ReplaceAll(requestContentType, "'", "\"")
+	}
+	_, params, err := mime.ParseMediaType(requestContentType)
 	if err != nil {
 		return jsonResponse{
 			status:       http.StatusBadRequest,


### PR DESCRIPTION
`gsutil` sends an invalid multipart boundary param, which golang's `mime.ParseMediaType` correctly rejects.
However, the real GCS evidently does not reject this, so in order to make `gsutil` work we need to support it.

In particular, `gsutil` sends a boundary param that is quoted using single-quotes when it should be using double-quotes.
In cases where the param is definitely invalid (so we're guarenteed not to break any valid values), we replace all single-quotes with double-quotes to produce the intended meaning.

Upstream bug: https://github.com/GoogleCloudPlatform/gsutil/issues/1466

Fixes https://github.com/fsouza/fake-gcs-server/issues/217
The above issue found this bug and worked around it, but found another problem and never submitted the fix.
It seems that in the intervening time, the other problem was fixed independently, and I can successfully `gsutil cp` using this code.