### PR TITLE
internal/config: always have an externalURL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,7 @@ func Load(args []string) (Config, error) {
 	var cfg Config
 	var allowedCORSHeaders string
 	var eventList string
-	var givenLogLevel string
+	var logLevel string
 
 	fs := flag.NewFlagSet("fake-gcs-server", flag.ContinueOnError)
 	fs.StringVar(&cfg.backend, "backend", filesystemBackend, "storage backend (memory or filesystem)")
@@ -78,14 +78,14 @@ func Load(args []string) (Config, error) {
 	fs.StringVar(&cfg.bucketLocation, "location", "US-CENTRAL1", "location for buckets")
 	fs.StringVar(&cfg.CertificateLocation, "cert-location", "", "location for server certificate")
 	fs.StringVar(&cfg.PrivateKeyLocation, "private-key-location", "", "location for private key")
-	fs.StringVar(&givenLogLevel, "log-level", "info", "level for logging. Options same as for logrus: trace, debug, info, warn, error, fatal, and panic")
+	fs.StringVar(&logLevel, "log-level", "info", "level for logging. Options same as for logrus: trace, debug, info, warn, error, fatal, and panic")
 
 	err := fs.Parse(args)
 	if err != nil {
 		return cfg, err
 	}
 
-	cfg.LogLevel, err = logrus.ParseLevel(givenLogLevel)
+	cfg.LogLevel, err = logrus.ParseLevel(logLevel)
 	if err != nil {
 		return cfg, err
 	}
@@ -95,6 +95,10 @@ func Load(args []string) (Config, error) {
 	}
 	if eventList != "" {
 		cfg.event.list = strings.Split(eventList, ",")
+	}
+
+	if cfg.externalURL == "" {
+		cfg.externalURL = fmt.Sprintf("%s://%s:%d", cfg.Scheme, cfg.Host, cfg.Port)
 	}
 
 	return cfg, cfg.validate()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,7 +68,7 @@ func TestLoadConfig(t *testing.T) {
 				backend:            "filesystem",
 				fsRoot:             "/storage",
 				publicHost:         "storage.googleapis.com",
-				externalURL:        "",
+				externalURL:        "https://0.0.0.0:4443",
 				allowedCORSHeaders: nil,
 				Host:               "0.0.0.0",
 				Port:               4443,


### PR DESCRIPTION
This is a regression introduced in #1159: when default parameters are used, the external URL would be empty, breaking resumable uploads.

Fixes #1166.
Fixes #1170.