### PR TITLE
Send X-Goog-Stored-Content-Encoding header

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -887,6 +887,13 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 		if obj.ContentEncoding != "" && !transcoded {
 			w.Header().Set("Content-Encoding", obj.ContentEncoding)
 		}
+		// X-Goog-Stored-Content-Encoding must be set to the original encoding,
+		// defaulting to "identity" if no encoding was set.
+		storedContentEncoding := "identity"
+		if obj.ContentEncoding != "" {
+			storedContentEncoding = obj.ContentEncoding
+		}
+		w.Header().Set("X-Goog-Stored-Content-Encoding", storedContentEncoding)
 	}
 
 	w.WriteHeader(status)

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -392,7 +392,9 @@ func TestServerClientObjectTranscoding(t *testing.T) {
 				Name:            objectName,
 				ContentType:     contentType,
 				ContentEncoding: contentEncoding,
-				Crc32c:          checksum.EncodedCrc32cChecksum([]byte(content)),
+				// At storage time the CRC32C must be set to the CRC32C of the
+				// compressed data.
+				Crc32c: checksum.EncodedCrc32cChecksum(b.Bytes()),
 			},
 			Content: b.Bytes(),
 		},


### PR DESCRIPTION
Fixes #1226

I've also fixed some unit tests that were passing but shouldn't have been.