### PR TITLE
Additional bucket response attributes

### DIFF
--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -127,6 +127,9 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		// TODO: Test `attrs.Updated` as soon as it is available in the [`storage.BucketAttrs`][1] type
 		//       (not available as of cloud.google.com/go/storage v1.31.0)
 		//       [1]: https://pkg.go.dev/cloud.google.com/go/storage#BucketAttrs
+		if attrs.StorageClass != "STANDARD" {
+			t.Errorf("wrong bucket storage class returned\nwant %q\ngot  %q", "STANDARD", attrs.StorageClass)
+		}
 	})
 }
 

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -124,6 +124,9 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		if attrs.Created.Before(startTime.Truncate(time.Second)) || time.Now().Before(attrs.Created) {
 			t.Errorf("expecting bucket creation date between test start time %v and now %v, got %v", startTime, time.Now(), attrs.Created)
 		}
+		// TODO: Test `attrs.Updated` as soon as it is available in the [`storage.BucketAttrs`][1] type
+		//       (not available as of cloud.google.com/go/storage v1.31.0)
+		//       [1]: https://pkg.go.dev/cloud.google.com/go/storage#BucketAttrs
 	})
 }
 

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -43,6 +43,7 @@ type bucketResponse struct {
 	Name                  string            `json:"name"`
 	Versioning            *bucketVersioning `json:"versioning,omitempty"`
 	TimeCreated           string            `json:"timeCreated,omitempty"`
+	Updated               string            `json:"updated,omitempty"`
 	Location              string            `json:"location,omitempty"`
 }
 
@@ -58,6 +59,7 @@ func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {
 		DefaultEventBasedHold: bucket.DefaultEventBasedHold,
 		Versioning:            &bucketVersioning{bucket.VersioningEnabled},
 		TimeCreated:           formatTime(bucket.TimeCreated),
+		Updated:               formatTime(bucket.TimeCreated), // not tracking update times yet, reporting `updated` = `timeCreated`
 		Location:              location,
 	}
 }

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -45,6 +45,7 @@ type bucketResponse struct {
 	TimeCreated           string            `json:"timeCreated,omitempty"`
 	Updated               string            `json:"updated,omitempty"`
 	Location              string            `json:"location,omitempty"`
+	StorageClass          string            `json:"storageClass,omitempty"`
 }
 
 type bucketVersioning struct {
@@ -61,6 +62,7 @@ func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {
 		TimeCreated:           formatTime(bucket.TimeCreated),
 		Updated:               formatTime(bucket.TimeCreated), // not tracking update times yet, reporting `updated` = `timeCreated`
 		Location:              location,
+		StorageClass:          "STANDARD",
 	}
 }
 

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -294,6 +294,7 @@ func TestBucketAttrsStoreRetrieveUpdate(t *testing.T) {
 }
 
 func TestBucketCreateGetListDelete(t *testing.T) {
+	startTime := time.Now()
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		buckets, err := storage.ListBuckets()
 		if err != nil {
@@ -343,6 +344,9 @@ func TestBucketCreateGetListDelete(t *testing.T) {
 			}
 			if buckets[0].Name != bucket.Name {
 				t.Errorf("listed bucket has unexpected name. Expected %s, actual: %v", bucket.Name, buckets[0].Name)
+			}
+			if buckets[0].TimeCreated.Before(startTime.Truncate(time.Second)) || time.Now().Before(buckets[0].TimeCreated) {
+				t.Errorf("listed bucket has unexpected creation time. Expected between test start time %v and now %v, actual: %v", startTime, time.Now(), buckets[0].TimeCreated)
 			}
 			err = storage.DeleteBucket(bucket.Name)
 			if err != nil {

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -113,7 +113,11 @@ func (s *storageFS) ListBuckets() ([]Bucket, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to unescape object name %s: %w", info.Name(), err)
 			}
-			buckets = append(buckets, Bucket{Name: unescaped})
+			fileInfo, err := info.Info()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get file info for %s: %w", info.Name(), err)
+			}
+			buckets = append(buckets, Bucket{Name: unescaped, TimeCreated: timespecToTime(createTimeFromFileInfo(fileInfo))})
 		}
 	}
 	return buckets, nil


### PR DESCRIPTION
Include additional attributes in Bucket responses, so that `fake-gcs-server` can be used with certain client libraries that rely on those attributes being there (like [googleCloudStorageR](https://cran.r-project.org/web/packages/googleCloudStorageR)).

With these changes we include three additional attributes: `timeCreated` (was already present when using the Memory backend),  `updated` and `storageClass`.

So we go from:

```shell
curl -s 'http://localhost:8080/storage/v1/b/?project=my-dummy-project-id' | jq
{
  "kind": "storage#buckets",
  "items": [
    {
      "kind": "storage#bucket",
      "id": "my-bucket",
      "name": "my-bucket",
      "versioning": {},
      "location": "US-CENTRAL1"
    }
  ]
}
```

to:

```shell
curl -s 'http://localhost:8080/storage/v1/b/?project=my-dummy-project-id' | jq
{
  "kind": "storage#buckets",
  "items": [
    {
      "kind": "storage#bucket",
      "id": "my-bucket",
      "name": "my-bucket",
      "versioning": {},
      "timeCreated": "2023-07-22T09:01:26.287332+02:00",
      "updated": "2023-07-22T09:01:26.287332+02:00",
      "location": "US-CENTRAL1",
      "storageClass": "STANDARD"
    }
  ]
}
```