### PR TITLE
Omit `items` if empty in object list response

### DIFF
--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -21,7 +21,7 @@ func formatTime(t time.Time) string {
 
 type listResponse struct {
 	Kind     string   `json:"kind"`
-	Items    []any    `json:"items"`
+	Items    []any    `json:"items,omitempty"`
 	Prefixes []string `json:"prefixes,omitempty"`
 }
 


### PR DESCRIPTION
GCS does not include the `items` attribute in the response from the [object list][1] operation when it is empty (i.e., when there are no objects). With this commit we emulate that behavior.

Example responses from GCS:

```shell
$ curl 'https://storage.googleapis.com/storage/v1/b/<MY-BUCKET>/o/?prefix=nonexistent_path' -H "Authorization: Bearer <MY-TOKEN>"
{
  "kind": "storage#objects"
}
```

```shell
$ curl 'https://storage.googleapis.com/storage/v1/b/<MY-BUCKET>/o/?delimiter=%2F&prefix=only_dirs_inside%2F' -H "Authorization: Bearer <MY-TOKEN>"
{
  "kind": "storage#objects",
  "prefixes": [
    "only_dirs_inside/a_dir/"
  ]
}
```

[1]: https://cloud.google.com/storage/docs/json_api/v1/objects/list