### PR TITLE
backend/fs: some bucket attributes cleanup

### DIFF
--- a/internal/backend/bucket.go
+++ b/internal/backend/bucket.go
@@ -14,7 +14,7 @@ type Bucket struct {
 	DefaultEventBasedHold bool
 }
 
-const BucketMetadataSuffix = ".bucketMetadata"
+const bucketMetadataSuffix = ".bucketMetadata"
 
 type BucketAttrs struct {
 	DefaultEventBasedHold bool

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -94,7 +94,7 @@ func (s *storageFS) createBucket(name string, bucketAttrs BucketAttrs) error {
 	if err != nil {
 		return err
 	}
-	return writeFile(path+BucketMetadataSuffix, encoded, 0o600)
+	return writeFile(path+bucketMetadataSuffix, encoded, 0o600)
 }
 
 // ListBuckets returns a list of buckets from the list of directories in the
@@ -132,7 +132,7 @@ func (s *storageFS) UpdateBucket(bucketName string, attrsToUpdate BucketAttrs) e
 		return err
 	}
 	path := filepath.Join(s.rootDir, url.PathEscape(bucketName))
-	return writeFile(path+BucketMetadataSuffix, encoded, 0o600)
+	return writeFile(path+bucketMetadataSuffix, encoded, 0o600)
 }
 
 // GetBucket returns information about the given bucket, or an error if it
@@ -145,15 +145,15 @@ func (s *storageFS) GetBucket(name string) (Bucket, error) {
 	if err != nil {
 		return Bucket{}, err
 	}
-	attrs, err := s.getBucketAttributes(path)
+	attrs, err := getBucketAttributes(path)
 	if err != nil {
 		return Bucket{}, err
 	}
 	return Bucket{Name: name, VersioningEnabled: false, TimeCreated: timespecToTime(createTimeFromFileInfo(dirInfo)), DefaultEventBasedHold: attrs.DefaultEventBasedHold}, err
 }
 
-func (s *storageFS) getBucketAttributes(path string) (BucketAttrs, error) {
-	content, err := os.ReadFile(path + BucketMetadataSuffix)
+func getBucketAttributes(path string) (BucketAttrs, error) {
+	content, err := os.ReadFile(path + bucketMetadataSuffix)
 	if err != nil {
 		return BucketAttrs{}, err
 	}


### PR DESCRIPTION
Just unexporting the suffix constant and making a method that doesn't access the receiver a simple function.