### PR TITLE
Drop Go 1.19

### DIFF
--- a/.github/workflows/goreleaser-run.yml
+++ b/.github/workflows/goreleaser-run.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v4.0.1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - uses: goreleaser/goreleaser-action@v4.3.0
         env:

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v4.0.1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - uses: goreleaser/goreleaser-action@v4.3.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - 1.19
           - "1.20"
-          - "1.21.0-rc.4"
+          - "1.21"
         os:
           - macos
           - ubuntu
@@ -66,7 +65,7 @@ jobs:
       - uses: actions/setup-go@v4.0.1
         id: go
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - run: |
           go install honnef.co/go/tools/cmd/staticcheck@master
@@ -96,7 +95,7 @@ jobs:
       - uses: actions/setup-go@v4.0.1
         id: go
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: go-build
         run: go build -o fake-gcs-server

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsouza/fake-gcs-server/examples/go-example
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/storage v1.31.0

--- a/examples/go/go.sum
+++ b/examples/go/go.sum
@@ -61,6 +61,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -122,6 +123,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Will let dependabot upgrade the Docker image when it's available.