### PR TITLE
github/workflows/main: pin python to 3.11 in gsutil example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
             docker-image: python:latest
             entrypoint: /bin/bash
           - lang: gsutil
-            docker-image: python:latest
+            docker-image: python:3.11
             entrypoint: /bin/bash
           - lang: node
             docker-image: node:14-alpine


### PR DESCRIPTION
Don't want to fight any issues compiling things, if we stick to Python 3.11, we can download wheels.