### PR TITLE
Updated python example

### DIFF
--- a/examples/python/python.py
+++ b/examples/python/python.py
@@ -2,6 +2,16 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# How to run this example
+# 1 - Build the docker image by running the command "docker build -t fsouza/fake-gcs-server ."
+# 2 - Start the docker container: "docker run -d --name fake-gcs-server -p 4443:4443 -v ${PWD}/examples/data:/data fsouza/fake-gcs-server -scheme http"
+# 3 - Check if it's working by running: "curl http://0.0.0.0:4443/storage/v1/b"
+# 4 - Create a python virtual enviroment (Ex: python -m .venv venv)
+# 5 - Source the env (source .venv/bin/activate)
+# 7 - Go to the following directory examples/python: (cd examples/python)
+# 6 - Install requirements: "pip install -r requirements.txt" and "pip install -r requirements.in"
+# 7 - Run this script
+
 import tempfile
 
 from google.auth.credentials import AnonymousCredentials
@@ -10,6 +20,9 @@ from google.cloud import storage
 client = storage.Client(
     credentials=AnonymousCredentials(),
     project="test",
+    # This endpoint assumes that you are using the default port 4443 from the container.
+    # If you are using a different port you need to update this endpoint
+    client_options={"api_endpoint": "http://localhost:4443"},
 )
 
 # List the Buckets

--- a/examples/python/python.py
+++ b/examples/python/python.py
@@ -12,17 +12,28 @@
 # 6 - Install requirements: "pip install -r requirements.txt" and "pip install -r requirements.in"
 # 7 - Run this script
 
+# For additional info on how to run this example or setup the docker container check the
+# run script "ci/run-python-example.sh"
+
 import tempfile
+import os
 
 from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 
+# This endpoint assumes that you are using the default port 4443 from the container.
+# If you are using a different port you need to update this endpoint
+os.environ["STORAGE_EMULATOR_HOST"] = os.environ.get(
+    "STORAGE_EMULATOR_HOST", "http://localhost:4443"
+)
+
+
 client = storage.Client(
     credentials=AnonymousCredentials(),
     project="test",
-    # This endpoint assumes that you are using the default port 4443 from the container.
-    # If you are using a different port you need to update this endpoint
-    client_options={"api_endpoint": "http://localhost:4443"},
+    # Alternatively instead of using the global env STORAGE_EMULATOR_HOST. You can define it here.
+    # This will set this client object to point to the local google cloud storage.
+    # client_options={"api_endpoint": "http://localhost:4443"},
 )
 
 # List the Buckets

--- a/examples/python/python.py
+++ b/examples/python/python.py
@@ -22,10 +22,8 @@ from google.auth.credentials import AnonymousCredentials
 from google.cloud import storage
 
 # This endpoint assumes that you are using the default port 4443 from the container.
-# If you are using a different port you need to update this endpoint
-os.environ["STORAGE_EMULATOR_HOST"] = os.environ.get(
-    "STORAGE_EMULATOR_HOST", "http://localhost:4443"
-)
+# If you are using a different port, please set the environment variable STORAGE_EMULATOR_HOST.
+os.environ.setdefault("STORAGE_EMULATOR_HOST", "http://localhost:4443")
 
 
 client = storage.Client(

--- a/examples/python/python.py
+++ b/examples/python/python.py
@@ -9,7 +9,7 @@
 # 4 - Create a python virtual enviroment (Ex: python -m .venv venv)
 # 5 - Source the env (source .venv/bin/activate)
 # 7 - Go to the following directory examples/python: (cd examples/python)
-# 6 - Install requirements: "pip install -r requirements.txt" and "pip install -r requirements.in"
+# 6 - Install requirements: "pip install -r requirements.txt"
 # 7 - Run this script
 
 # For additional info on how to run this example or setup the docker container check the


### PR DESCRIPTION
I tried the python example and it is not working out of the box. The main issue that I was facing is:

```
google.api_core.exceptions.BadRequest: 400 GET https://storage.googleapis.com/storage/v1/b?project=test&projection=noAcl&prettyPrint=false: Invalid project number: 0. Project id: 0 is invalid or not found
```

I think the issue has to do with not setting the `api_endpoint` for the docker container.

The solution is to add
```
    client_options={"api_endpoint": "http://localhost:4443"},
```

Apart from that I added some instructions as to how to run this example.

