### PR TITLE
Fixed patchObject ignoring ContentType and ContentEncoding

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -1010,9 +1010,11 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	}
 
 	var payload struct {
-		Metadata   map[string]string `json:"metadata"`
-		CustomTime string
-		Acl        []acls
+		ContentType     string
+		ContentEncoding string
+		Metadata        map[string]string `json:"metadata"`
+		CustomTime      string
+		Acl             []acls
 	}
 	err := json.NewDecoder(r.Body).Decode(&payload)
 	if err != nil {
@@ -1024,6 +1026,8 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 
 	var attrsToUpdate backend.ObjectAttrs
 
+	attrsToUpdate.ContentType = payload.ContentType
+	attrsToUpdate.ContentEncoding = payload.ContentEncoding
 	attrsToUpdate.Metadata = payload.Metadata
 	attrsToUpdate.CustomTime = payload.CustomTime
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -44,7 +44,6 @@ func (g *Server) GetBucket(ctx context.Context, req *pb.GetBucketRequest) (*pb.B
 		TimeCreated:           timestamppb.New(bucket.TimeCreated),
 	}
 	return grpc_bucket, nil
-	///return GetBucketFromBackend(g.backend, req.Bucket)
 }
 
 func (g *Server) DeleteBucket(ctx context.Context, req *pb.DeleteBucketRequest) (*pb.Empty, error) {
@@ -148,7 +147,9 @@ func (g *Server) UpdateObject(ctx context.Context, req *pb.UpdateObjectRequest) 
 
 func (g *Server) PatchObject(ctx context.Context, req *pb.PatchObjectRequest) (*pb.Empty, error) {
 	attrs := backend.ObjectAttrs{
-		Metadata: req.Metadata.Metadata,
+		Metadata:        req.Metadata.Metadata,
+		ContentType:     req.Metadata.ContentType,
+		ContentEncoding: req.Metadata.ContentEncoding,
 	}
 	_, err := g.backend.PatchObject(req.Bucket, req.Object, attrs)
 	return &pb.Empty{}, err


### PR DESCRIPTION
I was trying to update object's ContentType and noticed that only metadata was updated, but not the ContentType upon looking at the code i noticed that its ignored entirely.

Most likely fixes https://github.com/fsouza/fake-gcs-server/issues/273