### PR TITLE
Remove unnecessary quoting around ETag in JSON response

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -854,7 +854,7 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Goog-Generation", strconv.FormatInt(obj.Generation, 10))
 	w.Header().Set("X-Goog-Hash", fmt.Sprintf("crc32c=%s,md5=%s", obj.Crc32c, obj.Md5Hash))
 	w.Header().Set("Last-Modified", obj.Updated.Format(http.TimeFormat))
-	w.Header().Set("ETag", obj.Etag)
+	w.Header().Set("ETag", fmt.Sprintf("%q", obj.Etag))
 	for name, value := range obj.Metadata {
 		w.Header().Set("X-Goog-Meta-"+name, value)
 	}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -177,7 +177,7 @@ func checkObjectAttrs(testObj Object, attrs *storage.ObjectAttrs, t *testing.T) 
 	if testObj.Content != nil && !bytes.Equal(attrs.MD5, checksum.MD5Hash(testObj.Content)) {
 		t.Errorf("wrong hash returned\nwant %d\ngot   %d", checksum.MD5Hash(testObj.Content), attrs.MD5)
 	}
-	expectedEtag := fmt.Sprintf("\"%s\"", checksum.EncodedHash(attrs.MD5))
+	expectedEtag := checksum.EncodedHash(attrs.MD5)
 	if attrs.Etag != expectedEtag {
 		t.Errorf("wrong Etag returned\nwant %s\ngot   %s", expectedEtag, attrs.Etag)
 	}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -504,7 +504,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	obj.Content = append(obj.Content, content...)
 	obj.Crc32c = checksum.EncodedCrc32cChecksum(obj.Content)
 	obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
-	obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+	obj.Etag = obj.Md5Hash
 	contentTypeHeader := r.Header.Get(contentTypeHeader)
 	if contentTypeHeader != "" {
 		obj.ContentType = contentTypeHeader

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -251,7 +251,7 @@ func (s *storageFS) CreateObject(obj StreamingObject, conditions Conditions) (St
 		obj.Md5Hash = hasher.EncodedMd5Hash()
 	}
 	if obj.Etag == "" {
-		obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+		obj.Etag = obj.Md5Hash
 	}
 
 	// TODO: Handle if metadata is not present more gracefully?

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -44,7 +44,7 @@ func (bm *bucketInMemory) addObject(obj Object) Object {
 		obj.Md5Hash = checksum.EncodedMd5Hash(obj.Content)
 	}
 	if obj.Etag == "" {
-		obj.Etag = fmt.Sprintf("%q", obj.Md5Hash)
+		obj.Etag = obj.Md5Hash
 	}
 	if obj.Size == 0 {
 		obj.Size = int64(len(obj.Content))


### PR DESCRIPTION
The JSON marshaller will already escape the value appropriately. Quoting the value explicitly beforehand is counterproductive, as the quotes introduced in that step would be considered legitimate part of the ETag value and would be themselves escaped when marshalling.

When setting the `ETag` HTTP response header, however, we do have to explicitly add the quoting. This is because double quotes are not added automatically for HTTP headers and, according to the [standard][1], the `ETag` header value _must_ be wrapped in double quotes.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag

Fixes #1327