### PR TITLE
Support the `projection` parameter in `getObject`

### DIFF
--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/internal/backend"
 )
 
@@ -122,6 +123,14 @@ type objectResponse struct {
 	SelfLink        string                 `json:"selfLink,omitempty"`
 	MediaLink       string                 `json:"mediaLink,omitempty"`
 	Metageneration  string                 `json:"metageneration,omitempty"`
+}
+
+func newProjectedObjectResponse(obj ObjectAttrs, externalURL string, projection storage.Projection) objectResponse {
+	objResponse := newObjectResponse(obj, externalURL)
+	if projection == storage.ProjectionNoACL {
+		objResponse.ACL = nil
+	}
+	return objResponse
 }
 
 func newObjectResponse(obj ObjectAttrs, externalURL string) objectResponse {


### PR DESCRIPTION
According to the behavior described in the [official documentation][1]. That is, ACL information should only be returned if `projection=full` is provided as GET parameter.

This behavior is not testeable using the Go GCS client, because it hardcodes the value `full` when performing the HTTP request (see [implementation][2]).

[1]: https://cloud.google.com/storage/docs/json_api/v1/objects/get#parameters
[2]: https://github.com/googleapis/google-cloud-go/blob/storage/v1.39.0/storage/http_client.go#L413