### PR TITLE
Additional object response attributes

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -556,7 +556,7 @@ func (s *Server) listObjects(r *http.Request) jsonResponse {
 	if err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
-	return jsonResponse{data: newListObjectsResponse(objs, prefixes)}
+	return jsonResponse{data: newListObjectsResponse(objs, prefixes, s.externalURL)}
 }
 
 func (s *Server) xmlListObjects(r *http.Request) xmlResponse {
@@ -642,7 +642,7 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 		header.Set("Accept-Ranges", "bytes")
 		return jsonResponse{
 			header: header,
-			data:   newObjectResponse(obj.ObjectAttrs),
+			data:   newObjectResponse(obj.ObjectAttrs, s.externalURL),
 		}
 	})
 
@@ -774,9 +774,9 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 	defer created.Close()
 
 	if vars["copyType"] == "copyTo" {
-		return jsonResponse{data: newObjectResponse(created.ObjectAttrs)}
+		return jsonResponse{data: newObjectResponse(created.ObjectAttrs, s.externalURL)}
 	}
-	return jsonResponse{data: newObjectRewriteResponse(created.ObjectAttrs)}
+	return jsonResponse{data: newObjectRewriteResponse(created.ObjectAttrs, s.externalURL)}
 }
 
 func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
@@ -1139,5 +1139,5 @@ func (s *Server) composeObject(r *http.Request) jsonResponse {
 
 	s.eventManager.Trigger(&backendObj, notification.EventFinalize, nil)
 
-	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs, s.externalURL)}
 }

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -15,6 +15,7 @@ import (
 	"hash/crc32"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -187,7 +188,7 @@ func checkObjectAttrs(testObj Object, attrs *storage.ObjectAttrs, t *testing.T) 
 		}
 	}
 	externalURL := "" // We don't set any `externalURL` value during tests.
-	expectedMediaLink := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalURL, testObj.BucketName, testObj.Name)
+	expectedMediaLink := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalURL, url.PathEscape(testObj.BucketName), url.PathEscape(testObj.Name))
 	if attrs.MediaLink != expectedMediaLink {
 		t.Errorf("wrong MediaLink returned\nwant %s\ngot  %s", expectedMediaLink, attrs.MediaLink)
 	}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -186,8 +186,8 @@ func checkObjectAttrs(testObj Object, attrs *storage.ObjectAttrs, t *testing.T) 
 			t.Errorf("wrong MetaHeader returned\nwant %s\ngot %v", testObj.Metadata["MetaHeader"], val)
 		}
 	}
-	externalUrl := "" // We don't set any `externalURL` value during tests.
-	expectedMediaLink := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalUrl, testObj.BucketName, testObj.Name)
+	externalURL := "" // We don't set any `externalURL` value during tests.
+	expectedMediaLink := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalURL, testObj.BucketName, testObj.Name)
 	if attrs.MediaLink != expectedMediaLink {
 		t.Errorf("wrong MediaLink returned\nwant %s\ngot  %s", expectedMediaLink, attrs.MediaLink)
 	}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -186,6 +186,14 @@ func checkObjectAttrs(testObj Object, attrs *storage.ObjectAttrs, t *testing.T) 
 			t.Errorf("wrong MetaHeader returned\nwant %s\ngot %v", testObj.Metadata["MetaHeader"], val)
 		}
 	}
+	externalUrl := "" // We don't set any `externalURL` value during tests.
+	expectedMediaLink := fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalUrl, testObj.BucketName, testObj.Name)
+	if attrs.MediaLink != expectedMediaLink {
+		t.Errorf("wrong MediaLink returned\nwant %s\ngot  %s", expectedMediaLink, attrs.MediaLink)
+	}
+	if attrs.Metageneration != 1 {
+		t.Errorf("wrong metageneration\nwant 1\ngot  %d", attrs.Metageneration)
+	}
 }
 
 func TestServerClientObjectAttrs(t *testing.T) {

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -66,14 +66,14 @@ func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {
 	}
 }
 
-func newListObjectsResponse(objs []ObjectAttrs, prefixes []string, externalUrl string) listResponse {
+func newListObjectsResponse(objs []ObjectAttrs, prefixes []string, externalURL string) listResponse {
 	resp := listResponse{
 		Kind:     "storage#objects",
 		Items:    make([]any, len(objs)),
 		Prefixes: prefixes,
 	}
 	for i, obj := range objs {
-		resp.Items[i] = newObjectResponse(obj, externalUrl)
+		resp.Items[i] = newObjectResponse(obj, externalURL)
 	}
 	return resp
 }
@@ -122,7 +122,7 @@ type objectResponse struct {
 	Metageneration  string                 `json:"metageneration,omitempty"`
 }
 
-func newObjectResponse(obj ObjectAttrs, externalUrl string) objectResponse {
+func newObjectResponse(obj ObjectAttrs, externalURL string) objectResponse {
 	acl := getAccessControlsListFromObject(obj)
 
 	return objectResponse{
@@ -143,8 +143,8 @@ func newObjectResponse(obj ObjectAttrs, externalUrl string) objectResponse {
 		Updated:         formatTime(obj.Updated),
 		CustomTime:      formatTime(obj.CustomTime),
 		Generation:      obj.Generation,
-		SelfLink:        externalUrl + "/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name,
-		MediaLink:       externalUrl + "/download/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name + "?alt=media",
+		SelfLink:        externalURL + "/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name,
+		MediaLink:       externalURL + "/download/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name + "?alt=media",
 		Metageneration:  "1",
 	}
 }
@@ -182,14 +182,14 @@ type rewriteResponse struct {
 	Resource            objectResponse `json:"resource"`
 }
 
-func newObjectRewriteResponse(obj ObjectAttrs, externalUrl string) rewriteResponse {
+func newObjectRewriteResponse(obj ObjectAttrs, externalURL string) rewriteResponse {
 	return rewriteResponse{
 		Kind:                "storage#rewriteResponse",
 		TotalBytesRewritten: obj.Size,
 		ObjectSize:          obj.Size,
 		Done:                true,
 		RewriteToken:        "",
-		Resource:            newObjectResponse(obj, externalUrl),
+		Resource:            newObjectResponse(obj, externalURL),
 	}
 }
 

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -5,6 +5,8 @@
 package fakestorage
 
 import (
+	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/fsouza/fake-gcs-server/internal/backend"
@@ -143,8 +145,8 @@ func newObjectResponse(obj ObjectAttrs, externalURL string) objectResponse {
 		Updated:         formatTime(obj.Updated),
 		CustomTime:      formatTime(obj.CustomTime),
 		Generation:      obj.Generation,
-		SelfLink:        externalURL + "/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name,
-		MediaLink:       externalURL + "/download/storage/v1/b/" + obj.BucketName + "/o/" + obj.Name + "?alt=media",
+		SelfLink:        fmt.Sprintf("%s/storage/v1/b/%s/o/%s", externalURL, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)),
+		MediaLink:       fmt.Sprintf("%s/download/storage/v1/b/%s/o/%s?alt=media", externalURL, url.PathEscape(obj.BucketName), url.PathEscape(obj.Name)),
 		Metageneration:  "1",
 	}
 }

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -249,7 +249,7 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 		return errToJsonResponse(err)
 	}
 	obj.Close()
-	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs, s.externalURL)}
 }
 
 type notImplementedSeeker struct {
@@ -297,7 +297,7 @@ func (s *Server) signedUpload(bucketName string, r *http.Request) jsonResponse {
 		return errToJsonResponse(err)
 	}
 	obj.Close()
-	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs, s.externalURL)}
 }
 
 func getObjectACL(predefinedACL string) []storage.ACLRule {
@@ -386,7 +386,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		return errToJsonResponse(err)
 	}
 	defer obj.Close()
-	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs)}
+	return jsonResponse{data: newObjectResponse(obj.ObjectAttrs, s.externalURL)}
 }
 
 func parseContentTypeParams(requestContentType string) (map[string]string, error) {
@@ -446,7 +446,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 		header.Set("X-Goog-Upload-Status", "active")
 	}
 	return jsonResponse{
-		data:   newObjectResponse(obj.ObjectAttrs),
+		data:   newObjectResponse(obj.ObjectAttrs, s.externalURL),
 		header: header,
 	}
 }
@@ -553,7 +553,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	}
 	return jsonResponse{
 		status: status,
-		data:   newObjectResponse(obj.ObjectAttrs),
+		data:   newObjectResponse(obj.ObjectAttrs, s.externalURL),
 		header: responseHeader,
 	}
 }


### PR DESCRIPTION
Some GCS client libraries (like [this one][1]), are quite strict when it comes to the set of attributes they expect to find in the response. If any of those attributes is missing, they fail to deserialize the response.

Here we introduce three new attributes in the Object response:
* `SelfLink`
* `MediaLink`
* `Metageneration`

`SelfLink` cannot be tested using the Go GCS client library, as it is not included in the [`ObjectAttrs`][2] struct.

For the `Metageneration` we just hardcode the value `"1"`, considering that we are not keeping track of it internally and `"1"` happens to be the correct value most of the times anyway.

[1]: https://crates.io/crates/google-cloud-storage
[2]: https://pkg.go.dev/cloud.google.com/go/storage@v1.39.0#ObjectAttrs

---

Edited: I believe this PR fixes #758, which I only noticed after the fact.