### PR TITLE
Don't omit `versioning.enabled` in bucket response

### DIFF
--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -52,7 +52,7 @@ type bucketResponse struct {
 }
 
 type bucketVersioning struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {


### PR DESCRIPTION
In Go's `json` package, `false` qualifies as _empty_ value for the purposes of marshalling (see `Marshal` [docs][1]).

In the bucket JSON response, the `versioning.enabled` attribute should still be present even when it is `false`. If omitted, some [client libraries][2] fail to deserialize the response.

This commit changes the marshalling of `versioning` from:

```json
"versioning": {}
```

to:

```json
"versioning": {
  "enabled": false
}
```

[1]: https://pkg.go.dev/encoding/json#Marshal
[2]: https://crates.io/crates/google-cloud-storage

---

I didn't bother writing a test for this, as it felt overkill, but let me know if you disagree.