### PR TITLE
Additional bucket response attributes

### DIFF
--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -130,6 +130,18 @@ func TestServerClientBucketAttrs(t *testing.T) {
 		if attrs.StorageClass != "STANDARD" {
 			t.Errorf("wrong bucket storage class returned\nwant %q\ngot  %q", "STANDARD", attrs.StorageClass)
 		}
+		if attrs.ProjectNumber != 0 {
+			t.Errorf("wrong bucket project number returned\nwant %q\ngot  %q", "0", attrs.ProjectNumber)
+		}
+		if attrs.MetaGeneration != 1 {
+			t.Errorf("wrong bucket metageneration returned\nwant %q\ngot  %q", "1", attrs.MetaGeneration)
+		}
+		if attrs.Etag != "RVRhZw==" {
+			t.Errorf("wrong bucket etag returned\nwant %q\ngot  %q", "RVRhZw==", attrs.Etag)
+		}
+		if attrs.LocationType != "region" {
+			t.Errorf("wrong bucket location type returned\nwant %q\ngot  %q", "region", attrs.LocationType)
+		}
 	})
 }
 

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -49,6 +49,10 @@ type bucketResponse struct {
 	Updated               string            `json:"updated,omitempty"`
 	Location              string            `json:"location,omitempty"`
 	StorageClass          string            `json:"storageClass,omitempty"`
+	ProjectNumber         string            `json:"projectNumber"`
+	Metageneration        string            `json:"metageneration"`
+	Etag                  string            `json:"etag"`
+	LocationType          string            `json:"locationType"`
 }
 
 type bucketVersioning struct {
@@ -66,6 +70,10 @@ func newBucketResponse(bucket backend.Bucket, location string) bucketResponse {
 		Updated:               formatTime(bucket.TimeCreated), // not tracking update times yet, reporting `updated` = `timeCreated`
 		Location:              location,
 		StorageClass:          "STANDARD",
+		ProjectNumber:         "0",
+		Metageneration:        "1",
+		Etag:                  "RVRhZw==",
+		LocationType:          "region",
 	}
 }
 


### PR DESCRIPTION
Include these attributes in the JSON response for buckets:

* `projectNumber`
* `metageneration`
* `etag`
* `locationType`

Some [client libraries][1] expect them to be present, and fail to deserialize the response otherwise.

We don't care too much about their values at this stage, so we just picked valid and reasonable constants.

[1]: https://crates.io/crates/google-cloud-storage