### PR TITLE
Additional ACL response attributes

### DIFF
--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1919,8 +1919,8 @@ func TestServerClientObjectProjection(t *testing.T) {
 
 		url := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o/%s", bucketName, objectName)
 		fullACL := []objectAccessControl{
-			{Bucket: bucketName, Object: objectName, Entity: "user-1", Role: "OWNER"},
-			{Bucket: bucketName, Object: objectName, Entity: "user-2", Role: "READER"},
+			{Bucket: bucketName, Object: objectName, Entity: "user-1", Role: "OWNER", Etag: "RVRhZw==", Kind: "storage#objectAccessControl"},
+			{Bucket: bucketName, Object: objectName, Entity: "user-2", Role: "READER", Etag: "RVRhZw==", Kind: "storage#objectAccessControl"},
 		}
 
 		t.Run("full projection", func(t *testing.T) {

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -179,6 +179,8 @@ func getAccessControlsListFromObject(obj ObjectAttrs) []*objectAccessControl {
 			Entity: string(aclRule.Entity),
 			Object: obj.Name,
 			Role:   string(aclRule.Role),
+			Etag:   "RVRhZw==",
+			Kind:   "storage#objectAccessControl",
 		}
 	}
 	return aclItems


### PR DESCRIPTION
Include these attributes in the JSON response for access control lists.

* `etag`
* `kind`

Some [client libraries][1] expect them to be present, and fail to deserialize the response otherwise.

The value for `kind` matches what the real GCS API returns. We don't care too much about the ETag value at this stage, so we just picked a valid constant.

[1]: https://crates.io/crates/google-cloud-storage