### PR TITLE
read config from environment variables

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"os"
 	"strings"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
@@ -60,6 +61,13 @@ type EventConfig struct {
 	list            []string
 }
 
+func envVarOrDefault(key string, defaultValue string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultValue
+}
+
 // Load parses the given arguments list and return a config object (and/or an
 // error in case of failures).
 func Load(args []string) (Config, error) {
@@ -69,7 +77,7 @@ func Load(args []string) (Config, error) {
 	var logLevel string
 
 	fs := flag.NewFlagSet("fake-gcs-server", flag.ContinueOnError)
-	fs.StringVar(&cfg.backend, "backend", filesystemBackend, "storage backend (memory or filesystem)")
+	fs.StringVar(&cfg.backend, "backend", envVarOrDefault("FAKE_GCS_BACKEND", filesystemBackend), "storage backend (memory or filesystem)")
 	fs.StringVar(&cfg.fsRoot, "filesystem-root", "/storage", "filesystem root (required for the filesystem backend). folder will be created if it doesn't exist")
 	fs.StringVar(&cfg.publicHost, "public-host", "storage.googleapis.com", "Optional URL for public host")
 	fs.StringVar(&cfg.externalURL, "external-url", "", "optional external URL, returned in the Location header for uploads. Defaults to the address where the server is running")


### PR DESCRIPTION
This is a first draft of reading configuration from environment variables (#561) . I chose a different approach than #1041, let me know what you think! I've only added support for a single arg for now: `backend` using the `FAKE_GCS_BACKEND` environment variable. I'll update the PR with the rest of the arguments if you think this is a good way of doing it.

I don't usually write golang, so please be thorough in your feedback :) 

Open questions:
- Is this a good approach?
- Should all arguments be supported?
- Do we need more tests?