### PR TITLE
Add omitempty to new timestorageclassupdated

### DIFF
--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -125,7 +125,7 @@ type objectResponse struct {
 	StorageClass            string                 `json:"storageClass"`
 	TimeCreated             string                 `json:"timeCreated,omitempty"`
 	TimeDeleted             string                 `json:"timeDeleted,omitempty"`
-	TimeStorageClassUpdated string                 `json:"timeStorageClassUpdated"`
+	TimeStorageClassUpdated string                 `json:"timeStorageClassUpdated,omitempty"`
 	Updated                 string                 `json:"updated,omitempty"`
 	Generation              int64                  `json:"generation,string"`
 	CustomTime              string                 `json:"customTime,omitempty"`


### PR DESCRIPTION
I think the lack of `omitempty` is the cause for my [issue here](https://github.com/fsouza/fake-gcs-server/issues/1632)

I did not test this if this works or not