### PR TITLE
add aliases to support specifying EventOptions

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -73,6 +73,10 @@ func NewServerWithHostPort(objects []Object, host string, port uint16) (*Server,
 	})
 }
 
+type EventManagerOptions = notification.EventManagerOptions
+
+type EventNotificationOptions = notification.EventNotificationOptions
+
 // Options are used to configure the server on creation.
 type Options struct {
 	InitialObjects []Object
@@ -111,7 +115,7 @@ type Options struct {
 
 	// EventOptions contains the events that should be published and the URL
 	// of the Google cloud function such events should be published to.
-	EventOptions notification.EventManagerOptions
+	EventOptions EventManagerOptions
 
 	// Location used for buckets in the server.
 	BucketsLocation string

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -75,8 +75,6 @@ func NewServerWithHostPort(objects []Object, host string, port uint16) (*Server,
 
 type EventManagerOptions = notification.EventManagerOptions
 
-type EventNotificationOptions = notification.EventNotificationOptions
-
 // Options are used to configure the server on creation.
 type Options struct {
 	InitialObjects []Object


### PR DESCRIPTION
This is done to enable specifying EventOptions when using NewServerWithOptions.

https://pkg.go.dev/github.com/fsouza/fake-gcs-server/fakestorage#NewServerWithOptions

Fixes #1695