### PR TITLE
Revert "fakestorage: remove unused type"

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -75,6 +75,8 @@ func NewServerWithHostPort(objects []Object, host string, port uint16) (*Server,
 
 type EventManagerOptions = notification.EventManagerOptions
 
+type EventNotificationOptions = notification.EventNotificationOptions
+
 // Options are used to configure the server on creation.
 type Options struct {
 	InitialObjects []Object


### PR DESCRIPTION
This reverts commit 5e84fc89d5d6fd7160234aed7cdf953751f98767.

Addresses code review comment from #1696.