### PR TITLE
Disallow uppercase in bucket names

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -16,7 +16,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var bucketRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$`)
+// https://cloud.google.com/storage/docs/buckets#naming
+var bucketRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*[a-z0-9]$`)
 
 // CreateBucket creates a bucket inside the server, so any API calls that
 // require the bucket name will recognize this bucket.

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -252,6 +252,7 @@ func TestServerClientBucketCreateValidation(t *testing.T) {
 		"or spaces",
 		"don't even try",
 		"no/slashes/either",
+		"uppercaseNOTallowed",
 	}
 
 	for _, bucketName := range bucketNames {


### PR DESCRIPTION
This updates the pattern for valid bucket names to remove support for uppercase characters.

Per https://cloud.google.com/storage/docs/buckets#naming:

> Bucket names can only contain lowercase letters, numeric characters, dashes (-), underscores (_), and dots (.).

I imagine this is a potentially breaking change depending on peoples' setups/fixture data, but this would have caught a bug for one of our projects when changing an internal naming pattern.