### PR TITLE
Add support for canceling resumable uploads

### DIFF
--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -304,6 +304,8 @@ func (s *Server) buildMuxer() {
 	handler.Path("/upload/storage/v1/b/{bucketName}/o/").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.insertObject))
 	handler.Path("/upload/storage/v1/b/{bucketName}/o").Methods(http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.uploadFileContent))
 	handler.Path("/upload/storage/v1/b/{bucketName}/o/").Methods(http.MethodPut).HandlerFunc(jsonToHTTPHandler(s.uploadFileContent))
+	handler.Path("/upload/storage/v1/b/{bucketName}/o").Methods(http.MethodDelete).HandlerFunc(jsonToHTTPHandler(s.deleteResumableUpload))
+	handler.Path("/upload/storage/v1/b/{bucketName}/o/").Methods(http.MethodDelete).HandlerFunc(jsonToHTTPHandler(s.deleteResumableUpload))
 	handler.Path("/upload/resumable/{uploadId}").Methods(http.MethodPut, http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.uploadFileContent))
 
 	// Batch endpoint

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -630,6 +630,10 @@ func parseContentRange(r string) (parsed contentRange, err error) {
 	return parsed, nil
 }
 
+func (s *Server) deleteResumableUpload(r *http.Request) jsonResponse {
+	return jsonResponse{status: 499}
+}
+
 func loadMetadata(rc io.ReadCloser) (*multipartMetadata, error) {
 	defer rc.Close()
 	var m multipartMetadata

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -720,6 +720,30 @@ func TestServerClientSimpleUploadNoName(t *testing.T) {
 	}
 }
 
+func TestServerClientDeleteResumableUpload(t *testing.T) {
+	server := NewServer(nil)
+	defer server.Stop()
+
+	req, err := http.NewRequest("DELETE", server.URL()+"/upload/storage/v1/b/other-bucket/o?uploadType=media&name=some/nice/object.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	expectedStatus := 499
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("wrong status code\nwant %d\ngot  %d", expectedStatus, resp.StatusCode)
+	}
+}
+
 func TestServerInvalidUploadType(t *testing.T) {
 	server := NewServer(nil)
 	defer server.Stop()


### PR DESCRIPTION
Closes #1767 

This PR adds support for canceling resumable uploads.
The implementation is based on the [guides](https://cloud.google.com/storage/docs/performing-resumable-uploads#cancel-upload) and observed behavior, as this functionality was not explicitly documented in the API references.

I'm new to Go, so please feel free to let me know if you have any concerns about naming conventions, code organization, or anything else.

Thanks for maintaining this great project!
