### PR TITLE
fix: avoid IncompleteRead on completed partial reads

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -943,7 +943,7 @@ func (s *Server) handleRange(obj StreamingObject, r *http.Request) (ranged bool,
 	//   Length: 40, Range: bytes=50-
 	case start >= obj.Size:
 		// This IS a ranged request, but it ISN'T satisfiable.
-		return true, 0, 0, false
+		return true, 0, -1, false
 	// Negative range, ignore range and return all content.
 	// Examples:
 	//   Length: 40, Range: bytes=30-20

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -610,6 +610,34 @@ func TestServerClientObjectRangeReader(t *testing.T) {
 	})
 }
 
+func TestServerClientObjectRangeReaderInvalid(t *testing.T) {
+	const (
+		bucketName  = "some-bucket"
+		objectName  = "items/data.txt"
+		content     = "some really nice but long content stored in my object"
+		contentType = "text/plain; charset=iso-8859"
+	)
+	objs := []Object{
+		{
+			ObjectAttrs: ObjectAttrs{
+				BucketName:  bucketName,
+				Name:        objectName,
+				ContentType: contentType,
+			},
+			Content: []byte(content),
+		},
+	}
+
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
+		client := server.Client()
+		objHandle := client.Bucket(bucketName).Object(objectName)
+		_, err := objHandle.NewRangeReader(context.TODO(), 500, 10)
+		if err == nil {
+			t.Fatal("unexpected <nil> error")
+		}
+	})
+}
+
 func TestServerClientObjectReaderAfterCreateObject(t *testing.T) {
 	const (
 		bucketName  = "staging-bucket"


### PR DESCRIPTION
Fix a bug in which the server would return a 416 reply with an empty body declaring a Content-Length of 1.

Closes #1761