### PR TITLE
Use default temporary directory in tests

### DIFF
--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -16,14 +15,6 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
-
-func tempDir() string {
-	if runtime.GOOS == "linux" {
-		return "/var/tmp"
-	} else {
-		return os.TempDir()
-	}
-}
 
 func TestServerClientUpdateBucketAttrs(t *testing.T) {
 	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
@@ -331,7 +322,7 @@ func TestServerClientListObjects(t *testing.T) {
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-02.jpg"}},
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/hi-res/party-03.jpg"}},
 	}
-	dir, err := os.MkdirTemp(tempDir(), "fakestorage-test-root-")
+	dir, err := os.MkdirTemp("", "fakestorage-test-root-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -17,16 +17,8 @@ import (
 	"github.com/fsouza/fake-gcs-server/internal/checksum"
 )
 
-func tempDir() string {
-	if runtime.GOOS == "linux" {
-		return "/var/tmp"
-	} else {
-		return os.TempDir()
-	}
-}
-
 func makeStorageBackends(t *testing.T) (map[string]Storage, func()) {
-	tempDir, err := os.MkdirTemp(tempDir(), "fakegcstest")
+	tempDir, err := os.MkdirTemp("", "fakegcstest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/fsouza/fake-gcs-server/internal/backend"
@@ -15,16 +14,8 @@ import (
 	pb "google.golang.org/genproto/googleapis/storage/v1"
 )
 
-func tempDir() string {
-	if runtime.GOOS == "linux" {
-		return "/var/tmp"
-	} else {
-		return os.TempDir()
-	}
-}
-
 func makeStorageBackends(t *testing.T) (map[string]backend.Storage, func()) {
-	tempDir, err := os.MkdirTemp(tempDir(), "fakegcstest-grpc")
+	tempDir, err := os.MkdirTemp("", "fakegcstest-grpc")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Removing the Linux temporary directory hardcode in unit tests as it breaks sandboxed builds.

---

For packaging `fake-gcs-server` in Nixpkgs (will need a new release with the fixes).