### PR TITLE
fakeserver: honor Stop

### DIFF
--- a/fakestorage/mux_transport.go
+++ b/fakestorage/mux_transport.go
@@ -5,15 +5,20 @@
 package fakestorage
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 )
 
 type muxTransport struct {
 	handler http.Handler
+	closed  bool
 }
 
 func (t *muxTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if t.closed {
+		return nil, errors.New("server closed")
+	}
 	w := httptest.NewRecorder()
 	t.handler.ServeHTTP(w, r)
 	return w.Result(), nil

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -44,7 +44,7 @@ const defaultPublicHost = "storage.googleapis.com"
 type Server struct {
 	backend      backend.Storage
 	uploads      sync.Map
-	transport    http.RoundTripper
+	transport    *muxTransport
 	ts           *httptest.Server
 	handler      http.Handler
 	options      Options
@@ -455,10 +455,8 @@ func (s *Server) publicHostMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 
 // Stop stops the server, closing all connections.
 func (s *Server) Stop() {
+	s.transport.closed = true
 	if s.ts != nil {
-		if transport, ok := s.transport.(*http.Transport); ok {
-			transport.CloseIdleConnections()
-		}
 		s.ts.Close()
 	}
 }


### PR DESCRIPTION
Problem: calling `server.Close()` does not actually close anything — requests can flow as they normally would.

That's because the client always uses `*muxTransport`, which wires directly into the handlers avoiding all the TCP/HTTP dance.

In days long gone, `Server.transport` used to be HTTP, and starting/stopping the fakeserver did what one would expect.

Add a test that asserts correct behavior (we depend on it in some our tests), also removing the `Server.transport` ambiguity, as there is no other use case in this repo.