### PR TITLE
Add support for NetBSD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           - darwin
           - freebsd
           - linux
+          - netbsd
           - openbsd
           - windows
         goarch:

--- a/internal/backend/time_bsd.go
+++ b/internal/backend/time_bsd.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || freebsd
+//go:build darwin || freebsd || netbsd
 
 package backend
 


### PR DESCRIPTION
When trying to build fake-gcs-server on NetBSD it fails with:

```
# github.com/fsouza/fake-gcs-server/internal/backend
internal/backend/fs.go:120:82: undefined: createTimeFromFileInfo
internal/backend/fs.go:156:82: undefined: createTimeFromFileInfo
```

This PR addresses that and now fake-gcs-server builds on NetBSD too.

(I have noticed that while updating Grafana Loki.)
