### PR TITLE
fix: gRPC/HTTP2 negotiation by enabling h2 protocol in TLS configEnable HTTP/2

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func createListener(logger *slog.Logger, cfg *config.Config, scheme string) (net
 			server.Close()
 			tlsConfig = server.TLS
 		}
+		tlsConfig.NextProtos = []string{"h2"}
 		listener = tls.NewListener(listener, tlsConfig)
 	}
 


### PR DESCRIPTION
## Problem

gRPC requests were failing with 404 errors because the server couldn't negotiate HTTP/2 connections properly.

## Solution
Added `tlsConfig.NextProtos = []string{"h2"}` to enable HTTP/2 protocol negotiation in the TLS configuration.
## Testing

```shell
# Start server
$ go run main.go -scheme both -backend memory

# Test gRPC (now works)
$ grpcurl -insecure 127.0.0.1:4443 google.storage.v1.Storage.ListBuckets
{}
```

## Before

logs:
```
time=2025-08-19T20:56:37.822+09:00 level=INFO msg="::1 - - [19/Aug/2025:20:56:37 +0900] \"PRI * HTTP/2.0\" 404 19\n"
```