### PR TITLE
Implement GET /storage/v1/b/{bucket}/storageLayout for standard buckets

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -160,13 +160,7 @@ func (s *Server) getBucketStorageLayout(r *http.Request) jsonResponse {
 	if err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
-	return jsonResponse{data: bucketStorageLayoutResponse{
-		Kind:                  "storage#storageLayout",
-		Bucket:                bucketName,
-		Location:              s.options.BucketsLocation,
-		LocationType:          "region",
-		HierarchicalNamespace: &bucketStorageLayoutHierarchicalNamespace{Enabled: false},
-	}}
+	return jsonResponse{data: newBucketStorageLayoutResponse(bucketName, s.options.BucketsLocation)}
 }
 
 func (s *Server) deleteBucket(r *http.Request) jsonResponse {

--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -154,6 +154,21 @@ func (s *Server) getBucket(r *http.Request) jsonResponse {
 	return jsonResponse{data: newBucketResponse(bucket, s.options.BucketsLocation, s.externalURL)}
 }
 
+func (s *Server) getBucketStorageLayout(r *http.Request) jsonResponse {
+	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
+	_, err := s.backend.GetBucket(bucketName)
+	if err != nil {
+		return jsonResponse{status: http.StatusNotFound}
+	}
+	return jsonResponse{data: bucketStorageLayoutResponse{
+		Kind:                  "storage#storageLayout",
+		Bucket:                bucketName,
+		Location:              s.options.BucketsLocation,
+		LocationType:          "region",
+		HierarchicalNamespace: &bucketStorageLayoutHierarchicalNamespace{Enabled: false},
+	}}
+}
+
 func (s *Server) deleteBucket(r *http.Request) jsonResponse {
 	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
 	err := s.backend.DeleteBucket(bucketName)

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -6,7 +6,9 @@ package fakestorage
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -370,4 +372,62 @@ func TestServerClientListObjects(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetBucketStorageLayout(t *testing.T) {
+	t.Parallel()
+	server, err := NewServerWithOptions(Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop()
+	const bucketName = "test-bucket"
+	server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+	client := server.HTTPClient()
+
+	t.Run("existing bucket", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, server.URL()+"/storage/v1/b/"+bucketName+"/storageLayout", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("wrong status code\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+		}
+		var layout bucketStorageLayoutResponse
+		if err := json.NewDecoder(resp.Body).Decode(&layout); err != nil {
+			t.Fatal(err)
+		}
+		if layout.Kind != "storage#storageLayout" {
+			t.Errorf("wrong kind\nwant %q\ngot  %q", "storage#storageLayout", layout.Kind)
+		}
+		if layout.Bucket != bucketName {
+			t.Errorf("wrong bucket\nwant %q\ngot  %q", bucketName, layout.Bucket)
+		}
+		if layout.LocationType != "region" {
+			t.Errorf("wrong locationType\nwant %q\ngot  %q", "region", layout.LocationType)
+		}
+		if layout.HierarchicalNamespace == nil || layout.HierarchicalNamespace.Enabled {
+			t.Errorf("expected hierarchicalNamespace.enabled = false")
+		}
+	})
+
+	t.Run("non-existent bucket", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, server.URL()+"/storage/v1/b/does-not-exist/storageLayout", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("wrong status code\nwant %d\ngot  %d", http.StatusNotFound, resp.StatusCode)
+		}
+	})
 }

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -61,6 +61,18 @@ type bucketVersioning struct {
 	Enabled bool `json:"enabled"`
 }
 
+type bucketStorageLayoutHierarchicalNamespace struct {
+	Enabled bool `json:"enabled"`
+}
+
+type bucketStorageLayoutResponse struct {
+	Kind                  string                                    `json:"kind"`
+	Bucket                string                                    `json:"bucket"`
+	Location              string                                    `json:"location,omitempty"`
+	LocationType          string                                    `json:"locationType,omitempty"`
+	HierarchicalNamespace *bucketStorageLayoutHierarchicalNamespace `json:"hierarchicalNamespace,omitempty"`
+}
+
 func newBucketResponse(bucket backend.Bucket, location string, externalURL string) bucketResponse {
 	return bucketResponse{
 		Kind:                  "storage#bucket",

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -61,18 +61,6 @@ type bucketVersioning struct {
 	Enabled bool `json:"enabled"`
 }
 
-type bucketStorageLayoutHierarchicalNamespace struct {
-	Enabled bool `json:"enabled"`
-}
-
-type bucketStorageLayoutResponse struct {
-	Kind                  string                                    `json:"kind"`
-	Bucket                string                                    `json:"bucket"`
-	Location              string                                    `json:"location,omitempty"`
-	LocationType          string                                    `json:"locationType,omitempty"`
-	HierarchicalNamespace *bucketStorageLayoutHierarchicalNamespace `json:"hierarchicalNamespace,omitempty"`
-}
-
 func newBucketResponse(bucket backend.Bucket, location string, externalURL string) bucketResponse {
 	return bucketResponse{
 		Kind:                  "storage#bucket",
@@ -89,6 +77,28 @@ func newBucketResponse(bucket backend.Bucket, location string, externalURL strin
 		Etag:                  "RVRhZw==",
 		LocationType:          "region",
 		SelfLink:              fmt.Sprintf("%s/storage/v1/b/%s", externalURL, url.PathEscape(bucket.Name)),
+	}
+}
+
+type bucketStorageLayoutResponse struct {
+	Kind                  string                                    `json:"kind"`
+	Bucket                string                                    `json:"bucket"`
+	Location              string                                    `json:"location,omitempty"`
+	LocationType          string                                    `json:"locationType,omitempty"`
+	HierarchicalNamespace *bucketStorageLayoutHierarchicalNamespace `json:"hierarchicalNamespace,omitempty"`
+}
+
+type bucketStorageLayoutHierarchicalNamespace struct {
+	Enabled bool `json:"enabled"`
+}
+
+func newBucketStorageLayoutResponse(bucketName string, location string) bucketStorageLayoutResponse {
+	return bucketStorageLayoutResponse{
+		Kind:                  "storage#storageLayout",
+		Bucket:                bucketName,
+		Location:              location,
+		LocationType:          "region",
+		HierarchicalNamespace: &bucketStorageLayoutHierarchicalNamespace{Enabled: false},
 	}
 }
 

--- a/fakestorage/server.go
+++ b/fakestorage/server.go
@@ -268,6 +268,7 @@ func (s *Server) buildMuxer() {
 		r.Path("/b").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.createBucketByPost))
 		r.Path("/b/").Methods(http.MethodPost).HandlerFunc(jsonToHTTPHandler(s.createBucketByPost))
 		r.Path("/b/{bucketName}").Methods(http.MethodGet).HandlerFunc(jsonToHTTPHandler(s.getBucket))
+		r.Path("/b/{bucketName}/storageLayout").Methods(http.MethodGet).HandlerFunc(jsonToHTTPHandler(s.getBucketStorageLayout))
 		r.Path("/b/{bucketName}").Methods(http.MethodPatch).HandlerFunc(jsonToHTTPHandler(s.updateBucket))
 		r.Path("/b/{bucketName}").Methods(http.MethodPost).Headers("X-HTTP-Method-Override", "PATCH").HandlerFunc(jsonToHTTPHandler(s.updateBucket))
 		r.Path("/b/{bucketName}").Methods(http.MethodDelete).HandlerFunc(jsonToHTTPHandler(s.deleteBucket))


### PR DESCRIPTION
## Problem

`GET /storage/v1/b/{bucket}/storageLayout` was unimplemented and returned `404 text/plain: "Not Found"`. Some clients call this endpoint to probe for Hierarchical Namespace (HNS) before performing operations. A non-JSON 404 is treated as a hard failure by those clients, causing them to abort before the actual operation is even attempted.

One confirmed case: the GCS Hadoop connector (v3.1.17) calls this endpoint before every object delete. The connector's `ApiErrorExtractor.requestFailure(e)` treats the non-JSON response as a fatal error, crashing the delete operation.

Fixes #2237.

## Solution

Add a handler for `GET /storage/v1/b/{bucket}/storageLayout` that returns the response shape defined by the [real GCS API](https://cloud.google.com/storage/docs/json_api/v1/buckets/getStorageLayout) for a standard (non-HNS) bucket:

```json
{
  "kind": "storage#storageLayout",
  "bucket": "my-bucket",
  "location": "US-CENTRAL1",
  "locationType": "region",
  "hierarchicalNamespace": { "enabled": false }
}
```

Returns a proper JSON 404 if the bucket does not exist.
