### PR TITLE
fix: return 400 for negative maxResults instead of panicking

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -424,7 +424,7 @@ func (s *Server) ListObjectsWithOptionsPaginated(bucketName string, options List
 	}
 	sort.Strings(respPrefixes)
 	nextPageToken := ""
-	if options.MaxResults != 0 && len(respObjects) > options.MaxResults {
+	if options.MaxResults > 0 && len(respObjects) > options.MaxResults {
 		nextPageToken = respObjects[options.MaxResults].Name
 		respObjects = respObjects[:options.MaxResults]
 	}
@@ -669,8 +669,11 @@ func (s *Server) listObjects(r *http.Request) jsonResponse {
 	var err error
 	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
 		maxResults, err = strconv.Atoi(maxResultsStr)
-		if err != nil {
-			return jsonResponse{status: http.StatusBadRequest}
+		if err != nil || maxResults < 0 {
+			return jsonResponse{
+				status:       http.StatusBadRequest,
+				errorMessage: fmt.Sprintf("invalid value for maxResults: %q", maxResultsStr),
+			}
 		}
 	}
 	response, err := s.ListObjectsWithOptionsPaginated(bucketName, ListOptions{


### PR DESCRIPTION
A negative maxResults query parameter (e.g. ?maxResults=-1) parsed successfully via strconv.Atoi and flowed into the pagination logic, where respObjects[options.MaxResults] panicked with index out of range. Real GCS treats maxResults as an unsigned integer and rejects invalid values with 400 Bad Request.

Reject negative values at the handler with 400, and guard the pagination slice with MaxResults > 0 so direct callers of the exported ListObjectsWithOptionsPaginated cannot panic the process either.