### PR TITLE
fix: return Content-Range and full body on 416 range responses

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -1077,10 +1077,16 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 
 	if ranged && !satisfiable {
 		status = http.StatusRequestedRangeNotSatisfiable
-		content = bytes.NewReader([]byte(fmt.Sprintf(`<?xml version='1.0' encoding='UTF-8'?>`+
+		body := []byte(fmt.Sprintf(`<?xml version='1.0' encoding='UTF-8'?>`+
 			`<Error><Code>InvalidRange</Code>`+
 			`<Message>The requested range cannot be satisfied.</Message>`+
-			`<Details>%s</Details></Error>`, r.Header.Get("Range"))))
+			`<Details>%s</Details></Error>`, r.Header.Get("Range")))
+		content = bytes.NewReader(body)
+		// GCS reports the unsatisfiable range against the total object size. The
+		// Content-Length set above is 0 for an unsatisfiable range, which would
+		// truncate the error body, so override it with the body length.
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", obj.Size))
+		w.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
 		w.Header().Set(contentTypeHeader, "application/xml; charset=UTF-8")
 	} else {
 		if obj.ContentType != "" {

--- a/fakestorage/server_test.go
+++ b/fakestorage/server_test.go
@@ -588,6 +588,7 @@ func testDownloadObjectRange(t *testing.T, server *Server) {
 		{"Partial range specified", map[string]string{"Range": "bytes=1-4"}, http.StatusPartialContent, "bytes 1-4/9", "omet"},
 		{"Exact range specified", map[string]string{"Range": "bytes=0-8"}, http.StatusPartialContent, "bytes 0-8/9", "something"},
 		{"Too-long range specified", map[string]string{"Range": "bytes=0-100"}, http.StatusPartialContent, "bytes 0-8/9", "something"},
+		{"Unsatisfiable range specified", map[string]string{"Range": "bytes=50-60"}, http.StatusRequestedRangeNotSatisfiable, "bytes */9", `<?xml version='1.0' encoding='UTF-8'?><Error><Code>InvalidRange</Code><Message>The requested range cannot be satisfied.</Message><Details>bytes=50-60</Details></Error>`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When a Range request's start is beyond the object size, downloadObject returned 416 but set Content-Length: 0 (computed from the unsatisfiable range), which truncated the XML error body to empty, and it never set a Content-Range header.

Real GCS answers an unsatisfiable range with 'Content-Range: bytes */<size>' and an InvalidRange error body. Set that header and override Content-Length with the body length so the error body is actually sent.