### PR TITLE
fix: return 200 on POST request to pre-signed URL made by gcloud CLI

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -639,6 +639,10 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if objName == "" {
 		objName = metadata.Name
 	}
+	// For XML resumable upload, object name is the path. Omit leading slash.
+	if objName == "" {
+		objName = strings.TrimPrefix(r.URL.Path, "/")
+	}
 	if contentEncoding == "" {
 		contentEncoding = metadata.ContentEncoding
 	}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -159,6 +160,19 @@ func (s *Server) insertObject(r *http.Request) jsonResponse {
 				return s.signedUpload(bucketName, r)
 			}
 		}
+
+		// Support initiating resumable upload using XML API
+		var headers []string
+		switch {
+		case r.URL.Query().Has("X-Goog-SignedHeaders"):
+			headers = strings.Split(r.URL.Query().Get("X-Goog-SignedHeaders"), ";")
+		case r.URL.Query().Has("x-goog-signedheaders"):
+			headers = strings.Split(r.URL.Query().Get("x-goog-signedheaders"), ";")
+		}
+		if slices.Contains(headers, "x-goog-resumable") {
+			return s.resumableUpload(bucketName, r)
+		}
+
 		return jsonResponse{errorMessage: "invalid uploadType", status: http.StatusBadRequest}
 	}
 }


### PR DESCRIPTION
# Problem
The current code checks for the presence of the `X-Goog-Algorithm` query parameter in order to dispatch this kind of request to the `(s *Server) resumableUpload` slot function. However, the capitalization of this query parameter depends on the way the pre-signed URL was created. Server applications that create signed URLs are instructed to capitalize this query parameter per the documentation: [signing URLs manually](https://docs.cloud.google.com/storage/docs/access-control/signing-urls-manually#algorithm)

However, signed URLs created using the gcloud CLI make all of the required query parameters lowercase:
```zsh
gcloud storage sign-url gs://test-bucket/test-object --http-verb=POST --headers=x-goog-resumable=start,content-type=application/octet-stream --impersonate-service-account=[ACCOUNT] --region=us-east4

# outputs URL with "x-goog-signature", "x-goog-algorithm", etc
```

This is interesting behavior because the required query string parameters in a [canonical request](https://docs.cloud.google.com/storage/docs/authentication/canonical-requests#required-query-parameters) are pascal cased... (could it be a bug in the gcloud cli?)

# Solution
All POST requests using pre-signed URLs that initiate a resumable upload using the XML API have a query parameter `x-goog-signedheaders` or `X-Goog-SignedHeaders` containing a `;` delimited list of names of headers defined in the canonical request. Resumable upload requests must have the header `x-goog-resumable: start`, so `x-goog-resumable` will appear in this list if this URL is for a resumable upload:
- https://docs.cloud.google.com/storage/docs/authentication/canonical-requests#required-query-parameters
- https://docs.cloud.google.com/storage/docs/performing-resumable-uploads#initiate-session

The patch just checks if this query parameter exists on the URL and contains `x-goog-resumable`. If so, it dispatches to the `(s *Server) resumableUpload` slot function.

Fixes  #2254