### PR TITLE
fix: prevent gRPC ComposeObject panic with more than two sources

### DIFF
--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -155,9 +155,9 @@ func (g *Server) PatchObject(ctx context.Context, req *pb.PatchObjectRequest) (*
 
 // ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string)
 func (g *Server) ComposeObject(ctx context.Context, req *pb.ComposeObjectRequest) (*pb.Object, error) {
-	sourceObjNames := make([]string, 2)
-	for i := 0; i < len(req.SourceObjects); i++ {
-		sourceObjNames[i] = req.SourceObjects[i].Name
+	sourceObjNames := make([]string, len(req.SourceObjects))
+	for i, src := range req.SourceObjects {
+		sourceObjNames[i] = src.Name
 	}
 	obj, err := g.backend.ComposeObject(req.DestinationBucket, sourceObjNames, req.DestinationObject, map[string]string{}, "", "", "", "", "", "")
 	return makeObject(obj), err

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -257,6 +257,55 @@ func TestObjectInsertGetUpdateCompose(t *testing.T) {
 	})
 }
 
+func TestComposeObjectManySources(t *testing.T) {
+	ctx := context.Background()
+
+	testForStorageBackends(t, func(t *testing.T, storage backend.Storage) {
+		grpcServer := InitServer(storage)
+		bucketName := "bucket1"
+		storage.CreateBucket(bucketName, backend.BucketAttrs{})
+
+		// Seed more than two source objects. The previous implementation
+		// allocated a fixed-length slice of 2, so composing more than two
+		// sources panicked with an index out of range.
+		sources := []struct {
+			name    string
+			content string
+		}{
+			{"source1", "a"},
+			{"source2", "b"},
+			{"source3", "c"},
+		}
+		var sourceObjects []*pb.ComposeObjectRequest_SourceObjects
+		for _, src := range sources {
+			obj := backend.Object{
+				ObjectAttrs: backend.ObjectAttrs{BucketName: bucketName, Name: src.name},
+				Content:     []byte(src.content),
+			}
+			if _, err := storage.CreateObject(obj.StreamingObject(), backend.NoConditions{}); err != nil {
+				t.Fatal(err)
+			}
+			sourceObjects = append(sourceObjects, &pb.ComposeObjectRequest_SourceObjects{Name: src.name})
+		}
+
+		composedName := "composed"
+		_, err := grpcServer.ComposeObject(ctx, &pb.ComposeObjectRequest{
+			DestinationBucket: bucketName,
+			DestinationObject: composedName,
+			SourceObjects:     sourceObjects,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		composed, err := storage.GetObject(bucketName, composedName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		contentEqual(t, composed.Content, []byte("abc"))
+	})
+}
+
 func TestBucketInsertGetListUpdateDelete(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
The gRPC ComposeObject handler allocated a fixed-length slice of 2 for the source object names, so composing more than two sources wrote past the end of the slice and panicked with "index out of range [2] with length 2". Fewer than two sources left trailing empty names. Allocate the slice to match the number of source objects.