### PR TITLE
fix: use GCS reason enums in JSON error responses

### DIFF
--- a/fakestorage/json_response.go
+++ b/fakestorage/json_response.go
@@ -65,9 +65,37 @@ func (r *jsonResponse) getErrorList(status int) []apiError {
 	} else {
 		return []apiError{{
 			Domain:  "global",
-			Reason:  http.StatusText(status),
+			Reason:  gcsErrorReason(status),
 			Message: r.getErrorMessage(status),
 		}}
+	}
+}
+
+// gcsErrorReason maps an HTTP status code to the reason string used by the GCS
+// JSON API error model. These reasons are domain-specific enums distinct from
+// the HTTP status text, e.g. 412 is "conditionNotMet" rather than "Precondition
+// Failed" and 404 is "notFound" rather than "Not Found".
+// See https://cloud.google.com/storage/docs/json_api/v1/status-codes
+func gcsErrorReason(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid"
+	case http.StatusForbidden:
+		return "forbidden"
+	case http.StatusNotFound:
+		return "notFound"
+	case http.StatusConflict:
+		return "conflict"
+	case http.StatusPreconditionFailed:
+		return "conditionNotMet"
+	case http.StatusTooManyRequests:
+		return "rateLimitExceeded"
+	case http.StatusInternalServerError:
+		return "internalError"
+	case http.StatusServiceUnavailable:
+		return "backendError"
+	default:
+		return http.StatusText(status)
 	}
 }
 

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -2404,7 +2404,7 @@ func TestServiceClientComposeObject(t *testing.T) {
 				"files/destination.txt",
 				[]string{"01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33"},
 				"",
-				"googleapi: Error 400: The number of source components provided (33) exceeds the maximum (32), Bad Request",
+				"googleapi: Error 400: The number of source components provided (33) exceeds the maximum (32), invalid",
 			},
 		}
 		for _, test := range tests {

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -238,7 +238,7 @@ func TestServerClientObjectWriterWithDoesNotExistPrecondition(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected overwriting existing object to fail, but received no error")
 		}
-		if err.Error() != "googleapi: Error 412: Precondition failed, Precondition Failed" {
+		if err.Error() != "googleapi: Error 412: Precondition failed, conditionNotMet" {
 			t.Errorf("expected HTTP 412 precondition failed error, but got %v", err)
 		}
 
@@ -360,7 +360,7 @@ func TestServerClientObjectOperationsWithIfGenerationNotMatchPrecondition(t *tes
 		if err == nil {
 			t.Fatal("expected overwriting existing object to fail, but received no error")
 		}
-		if err.Error() != "googleapi: Error 412: Precondition failed, Precondition Failed" {
+		if err.Error() != "googleapi: Error 412: Precondition failed, conditionNotMet" {
 			t.Errorf("expected HTTP 412 precondition failed error, but got %v", err)
 		}
 


### PR DESCRIPTION
The JSON API error model returns a domain-specific reason enum, but the errors[].reason field was populated with the HTTP status text, e.g. "Not Found" instead of "notFound" and "Precondition Failed" instead of "conditionNotMet". Map the status codes the server emits to their GCS reason strings.

Two existing tests asserted the previous, incorrect reason text inside full error strings; update them to the real reasons (conditionNotMet, invalid).