### PR TITLE
fix: enforce generation preconditions on resumable uploads

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -115,6 +115,16 @@ func (c generationCondition) ConditionsMet(activeGeneration int64) bool {
 	return true
 }
 
+// resumableUploadEntry holds the in-progress object for a resumable upload
+// session along with any generation preconditions supplied when the session
+// was initiated. GCS sends preconditions (e.g. ifGenerationMatch) on the
+// initiating request, but the object is only created when the upload is
+// finalized, so the preconditions must be carried across both requests.
+type resumableUploadEntry struct {
+	obj        Object
+	conditions generationCondition
+}
+
 func (s *Server) insertObject(r *http.Request) jsonResponse {
 	// Only parse JSON body for resumable uploads with JSON content type
 	if r.Method == http.MethodPost &&
@@ -212,12 +222,17 @@ func (s *Server) handleBodyBasedResumableUpload(r *http.Request, body *resumable
 		},
 	}
 
+	conditions, err := s.wrapUploadPreconditions(r, bucketName, body.Name)
+	if err != nil {
+		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
+	}
+
 	// Generate upload ID and store the object for later resumable upload chunks
 	uploadID, err := generateUploadID()
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
-	s.uploads.Store(uploadID, obj)
+	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions})
 
 	// Create response headers
 	header := make(http.Header)
@@ -628,6 +643,10 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if contentEncoding == "" {
 		contentEncoding = metadata.ContentEncoding
 	}
+	conditions, err := s.wrapUploadPreconditions(r, bucketName, objName)
+	if err != nil {
+		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
+	}
 	obj := Object{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:         bucketName,
@@ -648,7 +667,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
-	s.uploads.Store(uploadID, obj)
+	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions})
 	header := make(http.Header)
 	location := fmt.Sprintf(
 		"%s/upload/storage/v1/b/%s/o?uploadType=resumable&name=%s&upload_id=%s",
@@ -709,7 +728,8 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	if !ok {
 		return jsonResponse{status: http.StatusNotFound}
 	}
-	obj := rawObj.(Object)
+	entry := rawObj.(resumableUploadEntry)
+	obj := entry.obj
 	// TODO: stream upload file content to and from disk (when using the FS
 	// backend, at least) instead of loading the entire content into memory.
 	content, err := loadContent(r.Body)
@@ -746,7 +766,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 	}
 	if commit {
 		s.uploads.Delete(uploadID)
-		streamingObject, err := s.createObject(obj.StreamingObject(), backend.NoConditions{})
+		streamingObject, err := s.createObject(obj.StreamingObject(), entry.conditions)
 		if err != nil {
 			return errToJsonResponse(err)
 		}
@@ -763,7 +783,7 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 			// Python client
 			status = http.StatusPermanentRedirect
 		}
-		s.uploads.Store(uploadID, obj)
+		s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: entry.conditions})
 	}
 	if r.Header.Get("X-Goog-Upload-Command") == "upload, finalize" {
 		responseHeader.Set("X-Goog-Upload-Status", "final")

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -256,6 +256,80 @@ func TestServerClientObjectWriterWithDoesNotExistPrecondition(t *testing.T) {
 	})
 }
 
+// TestServerResumableUploadPrecondition exercises the two-step resumable
+// upload API directly (init POST + finalize PUT), which is the path used by
+// the Google Cloud Storage SDKs (e.g. the Java client's createFrom). The
+// generation precondition is supplied on the initiating request but must be
+// enforced when the upload is finalized.
+func TestServerResumableUploadPrecondition(t *testing.T) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
+		const bucketName = "precondition-bucket"
+		const existingName = "existing-object.txt"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		server.CreateObject(Object{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: existingName},
+			Content:     []byte("original"),
+		})
+
+		client := server.HTTPClient()
+
+		// resumableUpload initiates a resumable session and finalizes it,
+		// returning the HTTP status of the finalize request.
+		resumableUpload := func(t *testing.T, objectName, query string) int {
+			t.Helper()
+			initURL := fmt.Sprintf("%s/upload/storage/v1/b/%s/o?uploadType=resumable&name=%s%s",
+				server.URL(), bucketName, objectName, query)
+			initReq, err := http.NewRequest(http.MethodPost, initURL, strings.NewReader(""))
+			if err != nil {
+				t.Fatal(err)
+			}
+			initResp, err := client.Do(initReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			location := initResp.Header.Get("Location")
+			_, _ = io.Copy(io.Discard, initResp.Body)
+			_ = initResp.Body.Close()
+			if initResp.StatusCode != http.StatusOK {
+				t.Fatalf("resumable init: expected 200, got %d", initResp.StatusCode)
+			}
+			if location == "" {
+				t.Fatal("resumable init: missing Location upload URL")
+			}
+
+			finalizeReq, err := http.NewRequest(http.MethodPut, location, strings.NewReader("new content"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizeResp, err := client.Do(finalizeReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, finalizeResp.Body)
+			_ = finalizeResp.Body.Close()
+			return finalizeResp.StatusCode
+		}
+
+		t.Run("ifGenerationMatch=0 fails when object exists", func(t *testing.T) {
+			if status := resumableUpload(t, existingName, "&ifGenerationMatch=0"); status != http.StatusPreconditionFailed {
+				t.Errorf("expected 412 Precondition Failed overwriting existing object, got %d", status)
+			}
+		})
+
+		t.Run("ifGenerationMatch=0 succeeds for new object", func(t *testing.T) {
+			if status := resumableUpload(t, "brand-new-object.txt", "&ifGenerationMatch=0"); status != http.StatusOK {
+				t.Errorf("expected 200 creating new object, got %d", status)
+			}
+		})
+
+		t.Run("no precondition overwrites existing object", func(t *testing.T) {
+			if status := resumableUpload(t, existingName, ""); status != http.StatusOK {
+				t.Errorf("expected 200 overwriting without precondition, got %d", status)
+			}
+		})
+	})
+}
+
 func TestServerClientObjectOperationsWithIfGenerationMatchPrecondition(t *testing.T) {
 	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		const (


### PR DESCRIPTION
Resumable uploads accepted ifGenerationMatch/ifGenerationNotMatch on the session-initiating request but discarded them when finalizing the upload, so the preconditions were silently ignored. Only the single-request multipart path enforced them.

GCS SDKs (e.g. the Java client's Storage.createFrom) use resumable uploads, so an If-None-Match: * (ifGenerationMatch=0) overwrite of an existing object incorrectly returned 200 instead of 412.

Carry the preconditions across the two-step flow: capture them with the upload session at initiation (resumableUpload and
handleBodyBasedResumableUpload) and enforce them when the object is created in uploadFileContent, instead of backend.NoConditions{}.