### PR TITLE
fix: return single ObjectAccessControl from object ACL insert

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -910,7 +910,18 @@ func (s *Server) setObjectACL(r *http.Request) jsonResponse {
 	}
 	defer obj.Close()
 
-	return jsonResponse{data: newACLListResponse(obj.ObjectAttrs)}
+	// The ObjectAccessControls: insert API returns the single created ACL
+	// entry, not a list.  Returning a list yields a response with no
+	// top-level "role", which makes strongly-typed clients such as the
+	// Google Cloud Storage Java SDK fail to decode the ACL role.
+	return jsonResponse{data: &objectAccessControl{
+		Bucket: obj.BucketName,
+		Entity: string(entity),
+		Object: obj.Name,
+		Role:   string(role),
+		Etag:   "RVRhZw==",
+		Kind:   "storage#objectAccessControl",
+	}}
 }
 
 func (s *Server) rewriteObject(r *http.Request) jsonResponse {


### PR DESCRIPTION
The ObjectAccessControls: insert endpoint (POST .../o/{object}/acl) returned an ACL list rather than the single created resource the real GCS JSON API returns.  Because the list wrapper has no top-level "role", strongly-typed clients such as the Google Cloud Storage Java SDK fail to decode it with "Empty enum constants not allowed".  Return the single objectAccessControl, matching getObjectACL and the real API.