### PR TITLE
fix: validate declared MD5/CRC32C checksums on upload

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -63,6 +63,8 @@ type multipartMetadata struct {
 	CustomTime         time.Time         `json:"customTime,omitempty"`
 	Name               string            `json:"name"`
 	StorageClass       string            `json:"storageClass"`
+	Md5Hash            string            `json:"md5Hash"`
+	Crc32c             string            `json:"crc32c"`
 	Metadata           map[string]string `json:"metadata"`
 	Retention          *jsonRetention    `json:"retention,omitempty"`
 }
@@ -96,6 +98,8 @@ type resumableUploadBody struct {
 	ContentLanguage    string            `json:"contentLanguage"`
 	StorageClass       string            `json:"storageClass"`
 	CustomTime         string            `json:"customTime"` // RFC3339
+	Md5Hash            string            `json:"md5Hash"`
+	Crc32c             string            `json:"crc32c"`
 	Metadata           map[string]string `json:"metadata"`
 	PredefinedACL      string            `json:"predefinedAcl"`
 }
@@ -116,13 +120,30 @@ func (c generationCondition) ConditionsMet(activeGeneration int64) bool {
 }
 
 // resumableUploadEntry holds the in-progress object for a resumable upload
-// session along with any generation preconditions supplied when the session
-// was initiated. GCS sends preconditions (e.g. ifGenerationMatch) on the
-// initiating request, but the object is only created when the upload is
-// finalized, so the preconditions must be carried across both requests.
+// session along with state supplied when the session was initiated but only
+// applied when the upload is finalized: generation preconditions (e.g.
+// ifGenerationMatch) and any client-declared MD5/CRC32C checksums. GCS sends
+// both on the initiating request, but the object is only created on finalize,
+// so they must be carried across both requests.
 type resumableUploadEntry struct {
-	obj        Object
-	conditions generationCondition
+	obj            Object
+	conditions     generationCondition
+	declaredMd5    string
+	declaredCrc32c string
+}
+
+// checkDeclaredChecksums verifies any client-declared MD5/CRC32C checksum
+// against the value computed from the uploaded content. GCS rejects an upload
+// whose declared checksum does not match the data with HTTP 400. Empty
+// declared values are not checked.
+func checkDeclaredChecksums(declaredMd5, declaredCrc32c, actualMd5, actualCrc32c string) error {
+	if declaredMd5 != "" && declaredMd5 != actualMd5 {
+		return fmt.Errorf("provided MD5 hash %q doesn't match calculated MD5 hash %q", declaredMd5, actualMd5)
+	}
+	if declaredCrc32c != "" && declaredCrc32c != actualCrc32c {
+		return fmt.Errorf("provided CRC32C %q doesn't match calculated CRC32C %q", declaredCrc32c, actualCrc32c)
+	}
+	return nil
 }
 
 func (s *Server) insertObject(r *http.Request) jsonResponse {
@@ -232,7 +253,7 @@ func (s *Server) handleBodyBasedResumableUpload(r *http.Request, body *resumable
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
-	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions})
+	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions, declaredMd5: body.Md5Hash, declaredCrc32c: body.Crc32c})
 
 	// Create response headers
 	header := make(http.Header)
@@ -588,6 +609,11 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		}
 	}
 
+	if err := checkDeclaredChecksums(metadata.Md5Hash, metadata.Crc32c,
+		checksum.EncodedMd5Hash(content), checksum.EncodedCrc32cChecksum(content)); err != nil {
+		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
+	}
+
 	obj := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:         bucketName,
@@ -667,7 +693,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
-	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions})
+	s.uploads.Store(uploadID, resumableUploadEntry{obj: obj, conditions: conditions, declaredMd5: metadata.Md5Hash, declaredCrc32c: metadata.Crc32c})
 	header := make(http.Header)
 	location := fmt.Sprintf(
 		"%s/upload/storage/v1/b/%s/o?uploadType=resumable&name=%s&upload_id=%s",
@@ -765,6 +791,10 @@ func (s *Server) uploadFileContent(r *http.Request) jsonResponse {
 		}
 	}
 	if commit {
+		if err := checkDeclaredChecksums(entry.declaredMd5, entry.declaredCrc32c, obj.Md5Hash, obj.Crc32c); err != nil {
+			s.uploads.Delete(uploadID)
+			return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
+		}
 		s.uploads.Delete(uploadID)
 		streamingObject, err := s.createObject(obj.StreamingObject(), entry.conditions)
 		if err != nil {

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -330,6 +330,133 @@ func TestServerResumableUploadPrecondition(t *testing.T) {
 	})
 }
 
+// TestServerUploadChecksumValidation verifies that uploads whose client-
+// declared md5Hash/crc32c does not match the content are rejected with HTTP
+// 400, like real GCS, across the multipart and resumable upload APIs used by
+// the GCS SDKs (e.g. the Java client, via s3proxy).
+func TestServerUploadChecksumValidation(t *testing.T) {
+	const bucketName = "checksum-bucket"
+	const content = "the quick brown fox"
+	goodMd5 := checksum.EncodedMd5Hash([]byte(content))
+	goodCrc32c := checksum.EncodedCrc32cChecksum([]byte(content))
+	const badMd5 = "rL0Y20xC+Fzt72VPzMSk2A==" // valid base64, wrong for the content
+	const badCrc32c = "AAAAAA=="              // 4 zero bytes, wrong for the content
+
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		client := server.HTTPClient()
+
+		multipartUpload := func(t *testing.T, name string, metadata map[string]any) int {
+			t.Helper()
+			metadata["name"] = name
+			var buf bytes.Buffer
+			w := multipart.NewWriter(&buf)
+			metaPart, err := w.CreatePart(map[string][]string{contentTypeHeader: {"application/json; charset=UTF-8"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := json.NewEncoder(metaPart).Encode(metadata); err != nil {
+				t.Fatal(err)
+			}
+			dataPart, err := w.CreatePart(map[string][]string{contentTypeHeader: {"text/plain"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := dataPart.Write([]byte(content)); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			url := fmt.Sprintf("%s/upload/storage/v1/b/%s/o?uploadType=multipart", server.URL(), bucketName)
+			req, err := http.NewRequest(http.MethodPost, url, &buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set(contentTypeHeader, "multipart/related; boundary="+w.Boundary())
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			return resp.StatusCode
+		}
+
+		resumableUpload := func(t *testing.T, name string, metadata map[string]any) int {
+			t.Helper()
+			metadata["name"] = name
+			body, err := json.Marshal(metadata)
+			if err != nil {
+				t.Fatal(err)
+			}
+			initURL := fmt.Sprintf("%s/upload/storage/v1/b/%s/o?uploadType=resumable", server.URL(), bucketName)
+			initReq, err := http.NewRequest(http.MethodPost, initURL, bytes.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			initReq.Header.Set(contentTypeHeader, "application/json")
+			initResp, err := client.Do(initReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			location := initResp.Header.Get("Location")
+			_, _ = io.Copy(io.Discard, initResp.Body)
+			_ = initResp.Body.Close()
+			if initResp.StatusCode != http.StatusOK {
+				t.Fatalf("resumable init: expected 200, got %d", initResp.StatusCode)
+			}
+			finalizeReq, err := http.NewRequest(http.MethodPut, location, strings.NewReader(content))
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizeResp, err := client.Do(finalizeReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = io.Copy(io.Discard, finalizeResp.Body)
+			_ = finalizeResp.Body.Close()
+			return finalizeResp.StatusCode
+		}
+
+		modes := []struct {
+			name   string
+			upload func(*testing.T, string, map[string]any) int
+		}{
+			{"multipart", multipartUpload},
+			{"resumable", resumableUpload},
+		}
+		cases := []struct {
+			name     string
+			metadata map[string]any
+			want     int
+		}{
+			{"good md5", map[string]any{"md5Hash": goodMd5}, http.StatusOK},
+			{"bad md5", map[string]any{"md5Hash": badMd5}, http.StatusBadRequest},
+			{"good crc32c", map[string]any{"crc32c": goodCrc32c}, http.StatusOK},
+			{"bad crc32c", map[string]any{"crc32c": badCrc32c}, http.StatusBadRequest},
+			{"good md5 and crc32c", map[string]any{"md5Hash": goodMd5, "crc32c": goodCrc32c}, http.StatusOK},
+			{"no checksum", map[string]any{}, http.StatusOK},
+		}
+		for _, mode := range modes {
+			t.Run(mode.name, func(t *testing.T) {
+				for i, tc := range cases {
+					t.Run(tc.name, func(t *testing.T) {
+						name := fmt.Sprintf("%s-%d", mode.name, i)
+						metadata := make(map[string]any, len(tc.metadata))
+						for k, v := range tc.metadata {
+							metadata[k] = v
+						}
+						if got := mode.upload(t, name, metadata); got != tc.want {
+							t.Errorf("declared %v: expected status %d, got %d", tc.metadata, tc.want, got)
+						}
+					})
+				}
+			})
+		}
+	})
+}
+
 func TestServerClientObjectOperationsWithIfGenerationMatchPrecondition(t *testing.T) {
 	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
 		const (


### PR DESCRIPTION
fake-gcs-server computed an object's MD5/CRC32C from the uploaded bytes but never compared them against a checksum declared by the client, so an upload whose md5Hash/crc32c did not match the data was silently accepted. Real GCS rejects such uploads with HTTP 400 and reason "invalid".

Parse the declared md5Hash/crc32c from the upload metadata and reject mismatches with 400 on the multipart and resumable upload paths (the single-request media/form paths stream their body and are left as-is).