### PR TITLE
fix: preserve bucket ACL across bucket updates in the fs backend

### DIFF
--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -94,6 +94,36 @@ func TestServerClientBucketACL(t *testing.T) {
 	})
 }
 
+// TestServerClientBucketACLSurvivesBucketUpdate ensures that updating
+// unrelated bucket attributes does not discard the bucket's ACL. Bucket
+// updates only carry the attributes being changed, so backends must merge
+// them into the existing attributes rather than replace them wholesale.
+func TestServerClientBucketACLSurvivesBucketUpdate(t *testing.T) {
+	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
+		const bucketName = "acl-update-bucket"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		ctx := context.Background()
+		bucket := server.Client().Bucket(bucketName)
+
+		if err := bucket.ACL().Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
+			t.Fatal(err)
+		}
+
+		// An update that says nothing about the ACL must not affect it.
+		if _, err := bucket.Update(ctx, storage.BucketAttrsToUpdate{DefaultEventBasedHold: true}); err != nil {
+			t.Fatal(err)
+		}
+
+		rules, err := bucket.ACL().List(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hasACLRule(rules, storage.AllUsers, storage.RoleReader) {
+			t.Errorf("expected allUsers READER to survive bucket update, got %+v", rules)
+		}
+	})
+}
+
 func hasACLRule(rules []storage.ACLRule, entity storage.ACLEntity, role storage.ACLRole) bool {
 	for _, r := range rules {
 		if r.Entity == entity && r.Role == role {

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -132,11 +132,20 @@ func (s *storageFS) UpdateBucket(bucketName string, attrsToUpdate BucketAttrs) e
 	if attrsToUpdate.VersioningEnabled {
 		return errors.New("not implemented: fs storage type does not support versioning yet")
 	}
-	encoded, err := json.Marshal(attrsToUpdate)
+	path := filepath.Join(s.rootDir, url.PathEscape(bucketName))
+	attrs, err := getBucketAttributes(path)
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(s.rootDir, url.PathEscape(bucketName))
+	// Merge in only the attributes carried by the update: replacing the stored
+	// attributes wholesale would discard the ACL, which is managed separately
+	// by UpdateBucketACL.
+	attrs.DefaultEventBasedHold = attrsToUpdate.DefaultEventBasedHold
+	attrs.VersioningEnabled = attrsToUpdate.VersioningEnabled
+	encoded, err := json.Marshal(attrs)
+	if err != nil {
+		return err
+	}
 	return writeFile(path+bucketMetadataSuffix, encoded, 0o600)
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #2261, which added the bucket ACL endpoints.

`storageFS.UpdateBucket` marshals the incoming `BucketAttrs` straight over the stored bucket metadata. But a bucket update only carries the attributes being changed — `getBucketAttrsToUpdate` never populates `ACL` — so **any** bucket update rewrites the metadata with a null ACL, silently discarding it.

`storageMemory.UpdateBucket` assigns individual fields, so it keeps the ACL. The two backends disagree:

```
ACL().Set(allUsers, READER) → bucket.Update(DefaultEventBasedHold: true) → re-read ACL
  memory:      [allUsers READER]
  filesystem:  []            ← silently wiped
```

That's the failure mode worth avoiding in a fake: the same test passes on the default backend and fails under `-backend filesystem`, with nothing in the code under test to point at.

## Solution

Read the stored attributes and merge in only the fields the update carries — mirroring what the neighbouring `UpdateBucketACL` already does.

Adds a regression test covering both backends; it fails on `filesystem` before this change.