### PR TITLE
fix: report bucket attributes from ListBuckets

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/internal/checksum"
 )
 
@@ -370,6 +371,48 @@ func TestBucketDuplication(t *testing.T) {
 		err = storage.CreateBucket(bucketName, BucketAttrs{VersioningEnabled: true})
 		if err == nil {
 			t.Fatal("we were expecting a bucket duplication error")
+		}
+	})
+}
+
+// TestBucketListReportsAttrs ensures ListBuckets reports the same bucket
+// attributes as GetBucket, rather than dropping the ones that live in the
+// bucket metadata.
+func TestBucketListReportsAttrs(t *testing.T) {
+	const bucketName = "attrs-bucket"
+	acl := []storage.ACLRule{{Entity: storage.AllUsers, Role: storage.RoleReader}}
+	testForStorageBackends(t, func(t *testing.T, storageBackend Storage) {
+		if err := storageBackend.CreateBucket(bucketName, BucketAttrs{DefaultEventBasedHold: true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := storageBackend.UpdateBucketACL(bucketName, acl); err != nil {
+			t.Fatal(err)
+		}
+
+		fromGet, err := storageBackend.GetBucket(bucketName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buckets, err := storageBackend.ListBuckets()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var fromList *Bucket
+		for i, bucket := range buckets {
+			if bucket.Name == bucketName {
+				fromList = &buckets[i]
+			}
+		}
+		if fromList == nil {
+			t.Fatalf("bucket %s missing from ListBuckets", bucketName)
+		}
+		if !reflect.DeepEqual(fromList.ACL, fromGet.ACL) {
+			t.Errorf("ListBuckets ACL differs from GetBucket:\nlist %+v\nget  %+v", fromList.ACL, fromGet.ACL)
+		}
+		if fromList.DefaultEventBasedHold != fromGet.DefaultEventBasedHold {
+			t.Errorf("ListBuckets DefaultEventBasedHold differs from GetBucket:\nlist %v\nget  %v",
+				fromList.DefaultEventBasedHold, fromGet.DefaultEventBasedHold)
 		}
 	})
 }

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -118,7 +118,17 @@ func (s *storageFS) ListBuckets() ([]Bucket, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get file info for %s: %w", info.Name(), err)
 			}
-			buckets = append(buckets, Bucket{Name: unescaped, TimeCreated: timespecToTime(createTimeFromFileInfo(fileInfo))})
+			attrs, err := getBucketAttributes(filepath.Join(s.rootDir, info.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get bucket attributes for %s: %w", info.Name(), err)
+			}
+			buckets = append(buckets, Bucket{
+				Name:                  unescaped,
+				VersioningEnabled:     attrs.VersioningEnabled,
+				TimeCreated:           timespecToTime(createTimeFromFileInfo(fileInfo)),
+				DefaultEventBasedHold: attrs.DefaultEventBasedHold,
+				ACL:                   attrs.ACL,
+			})
 		}
 	}
 	return buckets, nil

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -201,7 +201,7 @@ func (s *storageMemory) ListBuckets() ([]Bucket, error) {
 	defer s.mtx.RUnlock()
 	buckets := []Bucket{}
 	for _, bucketInMemory := range s.buckets {
-		buckets = append(buckets, Bucket{Name: bucketInMemory.Name, VersioningEnabled: bucketInMemory.VersioningEnabled, TimeCreated: bucketInMemory.TimeCreated, ACL: bucketInMemory.ACL})
+		buckets = append(buckets, bucketInMemory.Bucket)
 	}
 	return buckets, nil
 }


### PR DESCRIPTION
## Problem

Follow-up to #2261, which added the bucket ACL endpoints.

`ListBuckets` disagrees with `GetBucket` about the same bucket, on both backends:

- `storageFS.ListBuckets` builds each `Bucket` from the directory entry alone and never reads the bucket metadata, so `ACL`, `VersioningEnabled` and `DefaultEventBasedHold` are always reported as zero values.
- `storageMemory.ListBuckets` rebuilds the `Bucket` field by field and omits `DefaultEventBasedHold` (pre-dates #2261; it was previously hardcoded to `false`).

So the two backends also disagree with *each other* about the ACL — memory reports it, fs doesn't:

```
GetBucket   ACL=[allUsers READER]  DefaultEventBasedHold=true
ListBuckets
  memory:      ACL=[allUsers READER]  DefaultEventBasedHold=false   ← hold dropped
  filesystem:  ACL=[]                 DefaultEventBasedHold=false   ← both dropped
```

This isn't visible over the JSON API today, since `bucketResponse` has no `acl` field — but it's a tripwire for whoever adds one.

## Solution

Read the stored attributes in the fs backend, and return the embedded `Bucket` directly in the memory backend so it cannot drift out of sync again.

Adds a regression test asserting `ListBuckets`/`GetBucket` parity across both backends; it fails on both before this change.