### PR TITLE
delete metadata keys patched to null

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -1277,8 +1277,8 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 		ContentDisposition string
 		ContentLanguage    string
 		CacheControl       string
-		StorageClass       string            `json:"storageClass"`
-		Metadata           map[string]string `json:"metadata"`
+		StorageClass       string             `json:"storageClass"`
+		Metadata           map[string]*string `json:"metadata"`
 		CustomTime         string
 		Acl                []acls
 		Retention          *jsonRetention `json:"retention"`
@@ -1304,7 +1304,16 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 	attrsToUpdate.ContentLanguage = payload.ContentLanguage
 	attrsToUpdate.CacheControl = payload.CacheControl
 	attrsToUpdate.StorageClass = payload.StorageClass
-	attrsToUpdate.Metadata = payload.Metadata
+	if payload.Metadata != nil {
+		attrsToUpdate.Metadata = make(map[string]string, len(payload.Metadata))
+		for key, value := range payload.Metadata {
+			if value == nil {
+				attrsToUpdate.DeleteMetadataKey(key)
+			} else {
+				attrsToUpdate.Metadata[key] = *value
+			}
+		}
+	}
 	attrsToUpdate.CustomTime = payload.CustomTime
 
 	if len(payload.Acl) > 0 {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1892,7 +1892,7 @@ func TestObjectPatchWithMethodOverrideHeader(t *testing.T) {
 		})
 
 		client := server.HTTPClient()
-		patchMetadata := func(metadata map[string]string) error {
+		patchMetadata := func(metadata any) error {
 			payload, _ := json.Marshal(map[string]any{"metadata": metadata})
 			req, _ := http.NewRequest(http.MethodPost, server.URL()+"/storage/v1/b/bucket/o/obj", bytes.NewReader(payload))
 			req.Header.Set("Content-Type", "application/json")
@@ -1911,12 +1911,15 @@ func TestObjectPatchWithMethodOverrideHeader(t *testing.T) {
 		if err := patchMetadata(map[string]string{"k1": "v1_updated", "k3": "v3"}); err != nil {
 			t.Fatal(err)
 		}
+		if err := patchMetadata(map[string]any{"k2": nil}); err != nil {
+			t.Fatal(err)
+		}
 
 		obj, err := server.GetObject("bucket", "obj")
 		if err != nil {
 			t.Fatal(err)
 		}
-		checkObjectMetadata(obj.Metadata, map[string]string{"k1": "v1_updated", "k2": "v2", "k3": "v3"}, t)
+		checkObjectMetadata(obj.Metadata, map[string]string{"k1": "v1_updated", "k3": "v3"}, t)
 	})
 }
 

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -29,6 +29,7 @@ type ObjectAttrs struct {
 	Etag                 string
 	ACL                  []storage.ACLRule
 	Metadata             map[string]string
+	metadataKeysToDelete []string
 	Created              string
 	Deleted              string
 	Updated              string
@@ -36,6 +37,11 @@ type ObjectAttrs struct {
 	Generation           int64
 	RetentionMode        string
 	RetentionRetainUntil string
+}
+
+// DeleteMetadataKey marks a metadata key for deletion during a patch.
+func (o *ObjectAttrs) DeleteMetadataKey(key string) {
+	o.metadataKeysToDelete = append(o.metadataKeysToDelete, key)
 }
 
 // ID is used for comparing objects.
@@ -95,7 +101,9 @@ func (o *StreamingObject) patch(attrsToUpdate ObjectAttrs) {
 	currObjType := currObjValues.Type()
 	newObjValues := reflect.ValueOf(attrsToUpdate)
 	for i := 0; i < newObjValues.NumField(); i++ {
-		if reflect.Value.IsZero(newObjValues.Field(i)) {
+		if currObjType.Field(i).Name == "metadataKeysToDelete" {
+			continue
+		} else if reflect.Value.IsZero(newObjValues.Field(i)) {
 			continue
 		} else if currObjType.Field(i).Name == "Metadata" {
 			if o.Metadata == nil {
@@ -107,5 +115,8 @@ func (o *StreamingObject) patch(attrsToUpdate ObjectAttrs) {
 		} else {
 			currObjValues.Field(i).Set(newObjValues.Field(i))
 		}
+	}
+	for _, key := range attrsToUpdate.metadataKeysToDelete {
+		delete(o.Metadata, key)
 	}
 }


### PR DESCRIPTION
fixes #1468

object metadata patches were turning null values into empty strings, so the key stayed around instead of being deleted. this keeps null values through decoding and deletes those keys in the shared backend patch path.

tested with:

`go test ./fakestorage -run '^TestObjectPatchWithMethodOverrideHeader$' -count=1`

`go test -vet all -mod readonly ./...`

`go build ./...`

`staticcheck ./...`
