### PR TITLE
fix: take the fs backend mutex in bucket update paths

### DIFF
--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -142,6 +142,8 @@ func (s *storageFS) UpdateBucket(bucketName string, attrsToUpdate BucketAttrs) e
 	if attrsToUpdate.VersioningEnabled {
 		return errors.New("not implemented: fs storage type does not support versioning yet")
 	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	path := filepath.Join(s.rootDir, url.PathEscape(bucketName))
 	attrs, err := getBucketAttributes(path)
 	if err != nil {
@@ -160,6 +162,8 @@ func (s *storageFS) UpdateBucket(bucketName string, attrsToUpdate BucketAttrs) e
 }
 
 func (s *storageFS) UpdateBucketACL(bucketName string, acl []storage.ACLRule) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	path := filepath.Join(s.rootDir, url.PathEscape(bucketName))
 	attrs, err := getBucketAttributes(path)
 	if err != nil {


### PR DESCRIPTION
This PR originally fixed the two follow-ups from the #2261 review (fs `UpdateBucket` wiping ACLs, `ListBuckets` dropping them), but #2290 and #2291 landed the same fixes first — after rebasing, what remains is the locking gap:

`storageFS.UpdateBucket` and `storageFS.UpdateBucketACL` now read the stored bucket metadata and write back a merged result, but neither takes the backend mutex, unlike every other bucket method (`CreateBucket` locks, `GetBucket`/`ListBuckets` take the read lock). Two concurrent updates — e.g. a bucket PATCH racing an ACL change — can interleave the read-modify-write and silently drop one of the writes. This takes the write lock for the duration of both update paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)