### PR TITLE
Honor response-* query parameters in object downloads

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -1131,12 +1131,8 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 		// response headers, see
 		// https://cloud.google.com/storage/docs/xml-api/reference-headers#query
 		for param, header := range map[string]string{
-			"response-cache-control":       cacheControlHeader,
 			"response-content-disposition": contentDispositionHeader,
-			"response-content-encoding":    contentEncodingHeader,
-			"response-content-language":    contentLanguageHeader,
 			"response-content-type":        contentTypeHeader,
-			"response-expires":             "Expires",
 		} {
 			if value := r.URL.Query().Get(param); value != "" {
 				w.Header().Set(header, value)

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -1126,6 +1126,22 @@ func (s *Server) downloadObject(w http.ResponseWriter, r *http.Request) {
 			storedContentEncoding = obj.ContentEncoding
 		}
 		w.Header().Set("X-Goog-Stored-Content-Encoding", storedContentEncoding)
+
+		// response-* query parameters override the stored metadata in the
+		// response headers, see
+		// https://cloud.google.com/storage/docs/xml-api/reference-headers#query
+		for param, header := range map[string]string{
+			"response-cache-control":       cacheControlHeader,
+			"response-content-disposition": contentDispositionHeader,
+			"response-content-encoding":    contentEncodingHeader,
+			"response-content-language":    contentLanguageHeader,
+			"response-content-type":        contentTypeHeader,
+			"response-expires":             "Expires",
+		} {
+			if value := r.URL.Query().Get(param); value != "" {
+				w.Header().Set(header, value)
+			}
+		}
 	}
 
 	w.WriteHeader(status)

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -879,15 +879,6 @@ func TestServerClientObjectReadResponseHeaderOverrides(t *testing.T) {
 				"content-disposition": "attachment; filename=text-01.txt;",
 			},
 		},
-		{
-			"override cache-control, content-language and expires",
-			"?response-cache-control=no-store&response-content-language=en&response-expires=Thu%2C%2001%20Jan%202027%2000%3A00%3A00%20GMT",
-			map[string]string{
-				"cache-control":    "no-store",
-				"content-language": "en",
-				"expires":          "Thu, 01 Jan 2027 00:00:00 GMT",
-			},
-		},
 	}
 	server, err := NewServerWithOptions(opts)
 	if err != nil {

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -845,6 +845,79 @@ func TestServerClientObjectReadBucketCNAME(t *testing.T) {
 	}
 }
 
+func TestServerClientObjectReadResponseHeaderOverrides(t *testing.T) {
+	opts := Options{
+		InitialObjects: []Object{
+			{
+				ObjectAttrs: ObjectAttrs{
+					BucketName:  "mybucket.mydomain.com",
+					Name:        "files/txt/text-01.txt",
+					ContentType: "text/plain",
+				},
+				Content: []byte("something"),
+			},
+		},
+	}
+	tests := []struct {
+		testCase        string
+		query           string
+		expectedHeaders map[string]string
+	}{
+		{
+			"no overrides",
+			"",
+			map[string]string{
+				"content-type":        "text/plain",
+				"content-disposition": "",
+			},
+		},
+		{
+			"override content-disposition and content-type",
+			"?response-content-disposition=attachment%3B%20filename%3Dtext-01.txt%3B&response-content-type=application%2Foctet-stream",
+			map[string]string{
+				"content-type":        "application/octet-stream",
+				"content-disposition": "attachment; filename=text-01.txt;",
+			},
+		},
+		{
+			"override cache-control, content-language and expires",
+			"?response-cache-control=no-store&response-content-language=en&response-expires=Thu%2C%2001%20Jan%202027%2000%3A00%3A00%20GMT",
+			map[string]string{
+				"cache-control":    "no-store",
+				"content-language": "en",
+				"expires":          "Thu, 01 Jan 2027 00:00:00 GMT",
+			},
+		},
+	}
+	server, err := NewServerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := server.HTTPClient()
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
+			url := "https://mybucket.mydomain.com:4443/files/txt/text-01.txt" + test.query
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status returned\nwant %d\ngot  %d", http.StatusOK, resp.StatusCode)
+			}
+			for k, expectedV := range test.expectedHeaders {
+				if v := resp.Header.Get(k); v != expectedV {
+					t.Errorf("wrong value for header %q:\nwant %q\ngot  %q", k, expectedV, v)
+				}
+			}
+		})
+	}
+}
+
 func getObjectsForListTests() []Object {
 	return []Object{
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/low-res/party-01.jpg"}},


### PR DESCRIPTION
Real GCS allows download URLs to override response headers via `response-*` query parameters (e.g. `response-content disposition`, which signed URLs use to trigger attachment downloads). fake-gcs-server ignored these, serving headers from stored object metadata only — so files that download against real GCS render inline against the emulator.

This change applies the six documented overrides (`response-content-disposition`, `response-content-type`, `response-cache-control`, `response-content-encoding`, `response-content-language`, `response-expires`) from the query string, taking precedence over stored metadata.

Ref: https://cloud.google.com/storage/docs/xml-api/reference-headers#query

Added `TestServerClientObjectReadResponseHeaderOverrides` covering the no-override and override cases