### PR TITLE
feat: honor predefinedAcl and acl on bucket creation

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -89,6 +89,42 @@ func (s *Server) CreateBucketWithOpts(opts CreateBucketOpts) {
 	}
 }
 
+// bucketACLFromRequest resolves the ACL a bucket is created with. The
+// predefinedAcl query parameter and an explicit acl list are mutually
+// exclusive, as they are in the real API.
+func bucketACLFromRequest(predefinedACL string, acl []aclRule) ([]storage.ACLRule, error) {
+	if predefinedACL != "" && len(acl) > 0 {
+		return nil, errors.New("cannot provide both predefinedAcl and acl")
+	}
+	if predefinedACL != "" {
+		return predefinedBucketACL(predefinedACL)
+	}
+	rules := make([]storage.ACLRule, 0, len(acl))
+	for _, rule := range acl {
+		rules = append(rules, storage.ACLRule(rule))
+	}
+	return rules, nil
+}
+
+// predefinedBucketACL expands the predefined ACLs buckets.insert accepts.
+// Only the entries naming a public or authenticated scope are represented;
+// the project-scoped roles the real API adds have no meaning here, since the
+// emulator does not model projects.
+func predefinedBucketACL(predefinedACL string) ([]storage.ACLRule, error) {
+	switch predefinedACL {
+	case "publicRead":
+		return []storage.ACLRule{{Entity: "allUsers", Role: "READER"}}, nil
+	case "publicReadWrite":
+		return []storage.ACLRule{{Entity: "allUsers", Role: "WRITER"}}, nil
+	case "authenticatedRead":
+		return []storage.ACLRule{{Entity: "allAuthenticatedUsers", Role: "READER"}}, nil
+	case "private", "projectPrivate":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("invalid predefinedAcl: %q", predefinedACL)
+	}
+}
+
 func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 	// Minimal version of Bucket from google.golang.org/api/storage/v1
 
@@ -96,6 +132,7 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 		Name                  string            `json:"name,omitempty"`
 		Versioning            *bucketVersioning `json:"versioning,omitempty"`
 		DefaultEventBasedHold bool              `json:"defaultEventBasedHold,omitempty"`
+		ACL                   []aclRule         `json:"acl,omitempty"`
 	}
 
 	// Read the bucket props from the request body JSON
@@ -113,7 +150,12 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 		return jsonResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
 	}
 
-	_, err := s.backend.GetBucket(name)
+	acl, err := bucketACLFromRequest(r.URL.Query().Get("predefinedAcl"), data.ACL)
+	if err != nil {
+		return jsonResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
+	}
+
+	_, err = s.backend.GetBucket(name)
 	if err == nil {
 		return jsonResponse{
 			errorMessage: fmt.Sprintf(
@@ -126,7 +168,7 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 	}
 
 	// Create the named bucket
-	if err := s.backend.CreateBucket(name, backend.BucketAttrs{VersioningEnabled: versioning, DefaultEventBasedHold: defaultEventBasedHold}); err != nil {
+	if err := s.backend.CreateBucket(name, backend.BucketAttrs{VersioningEnabled: versioning, DefaultEventBasedHold: defaultEventBasedHold, ACL: acl}); err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
 

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -330,6 +330,93 @@ func TestServerClientBucketAttrsAfterCreateBucketByPost(t *testing.T) {
 	}
 }
 
+func TestServerClientBucketAttrsAfterCreateBucketWithACL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		testCase     string
+		bucketName   string
+		attrs        storage.BucketAttrs
+		expectedACL  []storage.ACLRule
+		expectFailed bool
+	}{
+		{
+			testCase:    "predefined publicRead",
+			bucketName:  "predefined-public-read",
+			attrs:       storage.BucketAttrs{PredefinedACL: "publicRead"},
+			expectedACL: []storage.ACLRule{{Entity: "allUsers", Role: "READER"}},
+		},
+		{
+			testCase:    "predefined authenticatedRead",
+			bucketName:  "predefined-authenticated-read",
+			attrs:       storage.BucketAttrs{PredefinedACL: "authenticatedRead"},
+			expectedACL: []storage.ACLRule{{Entity: "allAuthenticatedUsers", Role: "READER"}},
+		},
+		{
+			testCase:    "predefined private",
+			bucketName:  "predefined-private",
+			attrs:       storage.BucketAttrs{PredefinedACL: "private"},
+			expectedACL: nil,
+		},
+		{
+			testCase:    "explicit acl",
+			bucketName:  "explicit-acl",
+			attrs:       storage.BucketAttrs{ACL: []storage.ACLRule{{Entity: "allUsers", Role: "READER"}}},
+			expectedACL: []storage.ACLRule{{Entity: "allUsers", Role: "READER"}},
+		},
+		{
+			testCase:    "no acl",
+			bucketName:  "no-acl",
+			attrs:       storage.BucketAttrs{},
+			expectedACL: nil,
+		},
+		{
+			testCase:     "predefined and explicit acl are exclusive",
+			bucketName:   "both-acls",
+			attrs:        storage.BucketAttrs{PredefinedACL: "publicRead", ACL: []storage.ACLRule{{Entity: "allUsers", Role: "READER"}}},
+			expectFailed: true,
+		},
+		{
+			testCase:     "unknown predefined acl",
+			bucketName:   "unknown-predefined-acl",
+			attrs:        storage.BucketAttrs{PredefinedACL: "someUnknownValue"},
+			expectFailed: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.testCase, func(t *testing.T) {
+			runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
+				client := server.Client()
+				bucket := client.Bucket(test.bucketName)
+				err := bucket.Create(context.Background(), "whatever", &test.attrs)
+				if test.expectFailed {
+					if err == nil {
+						t.Fatal("unexpected <nil> error")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				acls, err := bucket.ACL().List(context.Background())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(acls) != len(test.expectedACL) {
+					t.Fatalf("wrong number of ACL rules\nwant %d\ngot  %d", len(test.expectedACL), len(acls))
+				}
+				for i, expected := range test.expectedACL {
+					if acls[i].Entity != expected.Entity || acls[i].Role != expected.Role {
+						t.Errorf("wrong ACL rule at %d\nwant %v %v\ngot  %v %v", i, expected.Entity, expected.Role, acls[i].Entity, acls[i].Role)
+					}
+				}
+			})
+		})
+	}
+}
+
 func TestServerClientBucketCreateValidation(t *testing.T) {
 	bucketNames := []string{
 		"..what-is-this",


### PR DESCRIPTION
buckets.insert accepts a predefinedAcl query parameter and an acl list in the request body, and the real API applies either to the new bucket. The handler decoded only name, versioning and defaultEventBasedHold, so both were accepted and silently dropped: a client asking for a publicRead bucket got a private one and no error, and had to follow up with a separate call to /b/{bucket}/acl to get the access it had already requested.

Nothing else was missing -- BucketAttrs already carries ACL, the backend already stores it, and the standalone bucket ACL endpoints already read and write it. Only the create path ignored the request.

Decode acl into the existing aclRule type, which already unmarshals the entity and role field names, and expand predefinedAcl for the values that name a public or authenticated scope. private and projectPrivate map to no rules, matching what the emulator already produces for a bucket created without an ACL, so the default is unchanged. The project-scoped roles the real API adds are omitted because the emulator does not model projects.

Reject a request carrying both predefinedAcl and acl, and one naming an unknown predefinedAcl, rather than silently preferring one.

Objects already had this: upload.go reads predefinedAcl on every upload path and maps it through getObjectACL. Buckets were the gap.