### PR TITLE
feat: honor destinationPredefinedAcl on object copy and compose

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -979,11 +979,19 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 	if _, err := s.backend.GetBucket(dstBucket); err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
+	// A destination ACL named on the request replaces the one inherited
+	// from the source, as it does in the real API.
+	dstACL := obj.ACL
+	if predefinedACL := r.URL.Query().Get(
+		"destinationPredefinedAcl"); predefinedACL != "" {
+		dstACL = getObjectACL(predefinedACL)
+	}
+
 	newObject := StreamingObject{
 		ObjectAttrs: ObjectAttrs{
 			BucketName:         dstBucket,
 			Name:               vars["destinationObject"],
-			ACL:                obj.ACL,
+			ACL:                dstACL,
 			ContentType:        metadata.ContentType,
 			ContentEncoding:    metadata.ContentEncoding,
 			ContentDisposition: metadata.ContentDisposition,
@@ -1438,7 +1446,15 @@ func (s *Server) composeObject(r *http.Request) jsonResponse {
 		sourceNames = append(sourceNames, n.Name)
 	}
 
-	backendObj, err := s.backend.ComposeObject(bucketName, sourceNames, destinationObject, composeRequest.Destination.Metadata, composeRequest.Destination.ContentType, composeRequest.Destination.ContentEncoding, composeRequest.Destination.ContentDisposition, composeRequest.Destination.ContentLanguage, composeRequest.Destination.CacheControl, composeRequest.Destination.StorageClass)
+	// Absent, the destination keeps whatever ACL it already had, which for a
+	// new object is the one CreateObject assigns.
+	var acl []storage.ACLRule
+	if predefinedACL := r.URL.Query().Get(
+		"destinationPredefinedAcl"); predefinedACL != "" {
+		acl = getObjectACL(predefinedACL)
+	}
+
+	backendObj, err := s.backend.ComposeObject(bucketName, sourceNames, destinationObject, composeRequest.Destination.Metadata, composeRequest.Destination.ContentType, composeRequest.Destination.ContentEncoding, composeRequest.Destination.ContentDisposition, composeRequest.Destination.ContentLanguage, composeRequest.Destination.CacheControl, composeRequest.Destination.StorageClass, acl)
 	if err != nil {
 		return jsonResponse{
 			status:       http.StatusInternalServerError,

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -2502,6 +2502,85 @@ func TestServiceClientComposeObject(t *testing.T) {
 	})
 }
 
+func TestServiceClientCopyObjectPredefinedACL(t *testing.T) {
+	const bucketName = "copy-acl-bucket"
+	objs := []Object{
+		{
+			ObjectAttrs: ObjectAttrs{
+				BucketName: bucketName,
+				Name:       "source.txt",
+				ACL: []storage.ACLRule{
+					{Entity: "projectOwner-test-project", Role: "OWNER"},
+				},
+			},
+			Content: []byte("some content"),
+		},
+	}
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
+		client := server.Client()
+		src := client.Bucket(bucketName).Object("source.txt")
+
+		// Without one, the destination inherits the source's ACL
+		dst := client.Bucket(bucketName).Object("inherited.txt")
+		if _, err := dst.CopierFrom(src).Run(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertObjectACL(t, dst, "projectOwner-test-project", "OWNER")
+
+		// With one, it replaces the inherited ACL
+		dst = client.Bucket(bucketName).Object("public.txt")
+		copier := dst.CopierFrom(src)
+		copier.PredefinedACL = "publicRead"
+		if _, err := copier.Run(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertObjectACL(t, dst, "allUsers", "READER")
+	})
+}
+
+func TestServiceClientComposeObjectPredefinedACL(t *testing.T) {
+	const bucketName = "compose-acl-bucket"
+	objs := []Object{
+		{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "source1.txt"},
+			Content:     []byte("some content"),
+		},
+		{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "source2.txt"},
+			Content:     []byte("other content"),
+		},
+	}
+	runServersTest(t, runServersOptions{objs: objs}, func(t *testing.T, server *Server) {
+		client := server.Client()
+		sources := []*storage.ObjectHandle{
+			client.Bucket(bucketName).Object("source1.txt"),
+			client.Bucket(bucketName).Object("source2.txt"),
+		}
+
+		dst := client.Bucket(bucketName).Object("public.txt")
+		composer := dst.ComposerFrom(sources...)
+		composer.PredefinedACL = "publicRead"
+		if _, err := composer.Run(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertObjectACL(t, dst, "allUsers", "READER")
+	})
+}
+
+func assertObjectACL(t *testing.T, obj *storage.ObjectHandle, entity storage.ACLEntity, role storage.ACLRole) {
+	t.Helper()
+	acls, err := obj.ACL().List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, acl := range acls {
+		if acl.Entity == entity && acl.Role == role {
+			return
+		}
+	}
+	t.Errorf("missing ACL rule\nwant %v %v\ngot  %v", entity, role, acls)
+}
+
 func TestServiceClientRewriteObjectNonExistentDestBucket(t *testing.T) {
 	const (
 		content     = "some content"

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -478,7 +478,7 @@ func concatObjectReaders(objects []StreamingObject) io.ReadSeekCloser {
 	return concatenatedContent{io.MultiReader(readers...)}
 }
 
-func (s *storageFS) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string) (StreamingObject, error) {
+func (s *storageFS) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string, acl []storage.ACLRule) (StreamingObject, error) {
 	var sourceObjects []StreamingObject
 	for _, n := range objectNames {
 		obj, err := s.GetObject(bucketName, n)
@@ -502,6 +502,7 @@ func (s *storageFS) ComposeObject(bucketName string, objectNames []string, desti
 			StorageClass:       storageClass,
 			Created:            now,
 			Updated:            now,
+			ACL:                acl,
 		},
 	}
 

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -362,7 +362,7 @@ func (s *storageMemory) UpdateObject(bucketName, objectName string, attrsToUpdat
 	return obj, nil
 }
 
-func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string) (StreamingObject, error) {
+func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string, acl []storage.ACLRule) (StreamingObject, error) {
 	var data []byte
 	for _, n := range objectNames {
 		obj, err := s.GetObject(bucketName, n)
@@ -401,6 +401,9 @@ func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, d
 		}
 	}
 
+	if acl != nil {
+		dest.ACL = acl
+	}
 	dest.Content = data
 	dest.Crc32c = ""
 	dest.Md5Hash = ""

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -33,7 +33,7 @@ type Storage interface {
 	DeleteObject(bucketName, objectName string) error
 	PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error)
 	UpdateObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error)
-	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string) (StreamingObject, error)
+	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string, acl []storage.ACLRule) (StreamingObject, error)
 	DeleteAllFiles() error
 }
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -159,7 +159,8 @@ func (g *Server) ComposeObject(ctx context.Context, req *pb.ComposeObjectRequest
 	for i, src := range req.SourceObjects {
 		sourceObjNames[i] = src.Name
 	}
-	obj, err := g.backend.ComposeObject(req.DestinationBucket, sourceObjNames, req.DestinationObject, map[string]string{}, "", "", "", "", "", "")
+	// Destination attributes are not carried over here, req.DestinationPredefinedAcl among them.
+	obj, err := g.backend.ComposeObject(req.DestinationBucket, sourceObjNames, req.DestinationObject, map[string]string{}, "", "", "", "", "", "", nil)
 	return makeObject(obj), err
 }
 


### PR DESCRIPTION
objects.copy, objects.rewrite and objects.compose all accept a destinationPredefinedAcl, and the real API applies it to the object they produce.  Neither handler read it: a rewrite gave the destination the source object's ACL, and a compose left whatever CreateObject assigns, so a client asking for a public destination got a private one and no error.

Take it from the query string in both, mapping it through the existing getObjectACL, which is what the upload paths already do for predefinedAcl.  A rewrite with no destination ACL keeps inheriting the source's, and a compose without one keeps whatever it had, so the default in each is unchanged.

Composing needs the ACL at the point the destination is built, so it joins the attributes ComposeObject already carries.  The gRPC compose passes nil: it forwards none of the destination attributes today, and wiring only the ACL would leave it the odd one out.

Objects uploaded through /upload already had this; copying and composing them did not.