### PR TITLE
fix: support fully qualified Pub/Sub topic names

### DIFF
--- a/internal/notification/registry.go
+++ b/internal/notification/registry.go
@@ -193,6 +193,7 @@ func (r *NotificationRegistry) getOrCreateClient(ctx context.Context, projectID 
 }
 
 func splitTopic(topic string) (string, string, error) {
+	topic = strings.TrimPrefix(topic, "//pubsub.googleapis.com/")
 	parts := strings.Split(topic, "/")
 	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "topics" {
 		return "", "", fmt.Errorf("invalid topic format %q: expected projects/{project}/topics/{name}", topic)

--- a/internal/notification/registry_test.go
+++ b/internal/notification/registry_test.go
@@ -96,6 +96,7 @@ func TestSplitTopic(t *testing.T) {
 		wantErr   bool
 	}{
 		{"projects/my-project/topics/my-topic", "my-project", "my-topic", false},
+		{"//pubsub.googleapis.com/projects/my-project/topics/my-topic", "my-project", "my-topic", false},
 		{"bad-format", "", "", true},
 		{"projects/p/notopics/t", "", "", true},
 	}


### PR DESCRIPTION
Current versions of the GCS client libraries use a fully specified topic format starting with a `//pubsub.googleapis.com/` prefix, see e.g. the [Python client](https://github.com/googleapis/google-cloud-python/blob/dfed785b9e092ede91cc94815b4ead748e41d528/packages/google-cloud-storage/google/cloud/storage/notification.py#L36). Currently the emulator chokes on these topic names. With this fix, both the old and the new format are supported.