### PR TITLE
Support deleting a specific object generation

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -799,19 +799,30 @@ func (s *Server) getObject(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteObject(r *http.Request) jsonResponse {
 	vars := unescapeMuxVars(mux.Vars(r))
-	obj, err := s.GetObjectStreaming(vars["bucketName"], vars["objectName"])
+	generationStr := r.FormValue("generation")
+	generation, err := strconv.ParseInt(generationStr, 10, 64)
+	if err != nil && generationStr != "" {
+		return jsonResponse{status: http.StatusBadRequest, errorMessage: errInvalidGeneration.Error()}
+	}
+	obj, err := s.objectWithGenerationOnValidGeneration(vars["bucketName"], vars["objectName"], generationStr)
 	// Calling Close before checking err is okay on objects, and the object
 	// may need to be closed whether or not there's an error.
 	defer obj.Close() //lint:ignore SA5001 // see above
 	if err == nil {
-		err = s.backend.DeleteObject(vars["bucketName"], vars["objectName"])
+		if generation > 0 {
+			err = s.backend.DeleteObjectWithGeneration(vars["bucketName"], vars["objectName"], generation)
+		} else {
+			err = s.backend.DeleteObject(vars["bucketName"], vars["objectName"])
+		}
 	}
 	if err != nil {
 		return jsonResponse{status: http.StatusNotFound}
 	}
 	bucket, _ := s.backend.GetBucket(obj.BucketName)
 	backendObj := toBackendObjects([]StreamingObject{obj})[0]
-	if bucket.VersioningEnabled {
+	// Deleting a specific generation removes it outright even on a
+	// versioning-enabled bucket; only a plain delete archives.
+	if bucket.VersioningEnabled && generation <= 0 {
 		s.triggerEvent(&backendObj, notification.EventArchive, nil)
 	} else {
 		s.triggerEvent(&backendObj, notification.EventDelete, nil)

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -199,6 +199,53 @@ func TestObjectCRUD(t *testing.T) {
 	}
 }
 
+func TestDeleteObjectWithGeneration(t *testing.T) {
+	const bucketName = "some-bucket"
+	const objectName = "versioned/object.txt"
+	storage, err := NewStorageMemory(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noError(t, storage.CreateBucket(bucketName, BucketAttrs{VersioningEnabled: true}))
+
+	makeObject := func(content string, generation int64) Object {
+		return Object{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName, Generation: generation},
+			Content:     []byte(content),
+		}
+	}
+	first, err := storage.CreateObject(makeObject("first", 1111).StreamingObject(), NoConditions{})
+	noError(t, err)
+	first.Close()
+	second, err := storage.CreateObject(makeObject("second", 2222).StreamingObject(), NoConditions{})
+	noError(t, err)
+	second.Close()
+
+	t.Log("deleting a missing generation errors")
+	shouldError(t, storage.DeleteObjectWithGeneration(bucketName, objectName, 9999))
+
+	t.Log("deleting an archived generation removes it outright and keeps the live object")
+	noError(t, storage.DeleteObjectWithGeneration(bucketName, objectName, 1111))
+	_, err = storage.GetObjectWithGeneration(bucketName, objectName, 1111)
+	shouldError(t, err)
+	live, err := storage.GetObject(bucketName, objectName)
+	noError(t, err)
+	if live.Generation != 2222 {
+		t.Errorf("wrong live generation\nwant 2222\ngot  %d", live.Generation)
+	}
+	live.Close()
+
+	t.Log("deleting the live generation removes it outright rather than archiving it")
+	noError(t, storage.DeleteObjectWithGeneration(bucketName, objectName, 2222))
+	_, err = storage.GetObject(bucketName, objectName)
+	shouldError(t, err)
+	objs, err := storage.ListObjects(bucketName, "", true)
+	noError(t, err)
+	if len(objs) != 0 {
+		t.Errorf("wrong number of versions remaining\nwant 0\ngot  %d", len(objs))
+	}
+}
+
 func TestObjectQueryErrors(t *testing.T) {
 	for _, versioningEnabled := range []bool{true, false} {
 		versioningEnabled := versioningEnabled

--- a/internal/backend/fs.go
+++ b/internal/backend/fs.go
@@ -431,6 +431,20 @@ func (s *storageFS) DeleteObject(bucketName, objectName string) error {
 	return os.Remove(path)
 }
 
+// DeleteObjectWithGeneration deletes a specific generation of an object.
+// The filesystem backend does not support versioning, so the generation
+// must match the live object's.
+func (s *storageFS) DeleteObjectWithGeneration(bucketName, objectName string, generation int64) error {
+	if generation != 0 {
+		obj, err := s.GetObjectWithGeneration(bucketName, objectName, generation)
+		if err != nil {
+			return err
+		}
+		obj.Close()
+	}
+	return s.DeleteObject(bucketName, objectName)
+}
+
 func (s *storageFS) PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -336,6 +336,37 @@ func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
 	return nil
 }
 
+// DeleteObjectWithGeneration deletes the named generation of an object,
+// live or archived.  Unlike a plain delete on a versioning-enabled bucket,
+// which archives the live object, deleting a specific generation removes
+// the data outright, matching Cloud Storage.
+func (s *storageMemory) DeleteObjectWithGeneration(bucketName, objectName string, generation int64) error {
+	if generation == 0 {
+		return s.DeleteObject(bucketName, objectName)
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	bucketInMemory, err := s.getBucketInMemory(bucketName)
+	if err != nil {
+		return err
+	}
+	obj := Object{ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName, Generation: generation}}
+	if index := findObject(obj, bucketInMemory.activeObjects, true); index >= 0 {
+		bucketInMemory.activeObjects = removeAt(bucketInMemory.activeObjects, index)
+	} else if index := findObject(obj, bucketInMemory.archivedObjects, true); index >= 0 {
+		bucketInMemory.archivedObjects = removeAt(bucketInMemory.archivedObjects, index)
+	} else {
+		return errors.New("object not found")
+	}
+	s.buckets[bucketName] = bucketInMemory
+	return nil
+}
+
+func removeAt(objects []Object, index int) []Object {
+	objects[index] = objects[len(objects)-1]
+	return objects[:len(objects)-1]
+}
+
 func (s *storageMemory) PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error) {
 	obj, err := s.GetObject(bucketName, objectName)
 	if err != nil {

--- a/internal/backend/storage.go
+++ b/internal/backend/storage.go
@@ -31,6 +31,7 @@ type Storage interface {
 	GetObject(bucketName, objectName string) (StreamingObject, error)
 	GetObjectWithGeneration(bucketName, objectName string, generation int64) (StreamingObject, error)
 	DeleteObject(bucketName, objectName string) error
+	DeleteObjectWithGeneration(bucketName, objectName string, generation int64) error
 	PatchObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error)
 	UpdateObject(bucketName, objectName string, attrsToUpdate ObjectAttrs) (StreamingObject, error)
 	ComposeObject(bucketName string, objectNames []string, destinationName string, metadata map[string]string, contentType string, contentEncoding string, contentDisposition string, contentLanguage string, cacheControl string, storageClass string) (StreamingObject, error)


### PR DESCRIPTION
DELETE on an object silently ignored the generation query parameter: it archived or removed the live object whatever generation the caller named, and a generation that was already archived could not be removed at all.  Parse the parameter and add DeleteObjectWithGeneration to the backend interface with Cloud Storage's semantics: deleting a named generation removes it outright, live or archived, even on a versioning-enabled bucket, where only a plain delete archives.