### PR TITLE
Do not archive a duplicate when a write reuses the live generation

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -256,6 +256,35 @@ func TestBucketAttrsUpdateVersioning(t *testing.T) {
 	})
 }
 
+func TestPatchObjectDoesNotArchive(t *testing.T) {
+	const bucketName = "some-bucket"
+	storage, err := NewStorageMemory(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noError(t, storage.CreateBucket(bucketName, BucketAttrs{VersioningEnabled: true}))
+
+	obj, err := storage.CreateObject(Object{
+		ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "patched", Generation: 1111},
+		Content:     []byte("content"),
+	}.StreamingObject(), NoConditions{})
+	noError(t, err)
+	obj.Close()
+
+	t.Log("a metadata update reusing the live generation does not archive a copy")
+	patched, err := storage.PatchObject(bucketName, "patched", ObjectAttrs{Metadata: map[string]string{"foo": "bar"}})
+	noError(t, err)
+	patched.Close()
+	if patched.Generation != obj.Generation {
+		t.Errorf("patch minted a new generation\nwant %d\ngot  %d", obj.Generation, patched.Generation)
+	}
+	objs, err := storage.ListObjects(bucketName, "", true)
+	noError(t, err)
+	if len(objs) != 1 {
+		t.Errorf("wrong number of versions after patch\nwant 1\ngot  %d", len(objs))
+	}
+}
+
 func TestBucketAttrsStoreRetrieveUpdate(t *testing.T) {
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		bucketName := "randombucket"

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -56,7 +56,10 @@ func (bm *bucketInMemory) addObject(obj Object) Object {
 	obj.Generation = getNewGenerationIfZero(obj.Generation)
 	index := findObject(obj, bm.activeObjects, false)
 	if index >= 0 {
-		if bm.VersioningEnabled {
+		// A write that reuses the live generation is a metadata update
+		// (PatchObject, the ACL handlers) rather than a new version; only
+		// a write that changes the generation archives the old one.
+		if bm.VersioningEnabled && bm.activeObjects[index].Generation != obj.Generation {
 			bm.activeObjects[index].Deleted = time.Now().Format(timestampFormat)
 			bm.cpToArchive(bm.activeObjects[index])
 		}


### PR DESCRIPTION
PatchObject and the ACL handlers persist through CreateObject carrying the object's existing generation.  On a versioning-enabled bucket every such metadata update archived a copy of the live object under the same generation it still holds, so a single ACL change made a versioned listing show two entries sharing an id.  A write that reuses the live generation now replaces it in place; only a write that changes the generation archives the old one, matching Cloud Storage, where a metadata update bumps the metageneration alone.