### PR TITLE
Mint a new generation when compose overwrites an object

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -226,6 +226,48 @@ func TestObjectQueryErrors(t *testing.T) {
 	}
 }
 
+func TestComposeObjectNewGeneration(t *testing.T) {
+	const bucketName = "some-bucket"
+	storage, err := NewStorageMemory(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noError(t, storage.CreateBucket(bucketName, BucketAttrs{VersioningEnabled: true}))
+
+	dest, err := storage.CreateObject(Object{
+		ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "dest", Generation: 1111},
+		Content:     []byte("old"),
+	}.StreamingObject(), NoConditions{})
+	noError(t, err)
+	dest.Close()
+	source, err := storage.CreateObject(Object{
+		ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: "source"},
+		Content:     []byte("source"),
+	}.StreamingObject(), NoConditions{})
+	noError(t, err)
+	source.Close()
+
+	composed, err := storage.ComposeObject(bucketName, []string{"source"}, "dest", nil, "text/plain", "", "", "", "", "")
+	noError(t, err)
+	composed.Close()
+	if composed.Generation == dest.Generation {
+		t.Errorf("compose reused the destination's generation %d", dest.Generation)
+	}
+
+	objs, err := storage.ListObjects(bucketName, "dest", true)
+	noError(t, err)
+	if len(objs) != 2 {
+		t.Errorf("wrong number of versions after compose\nwant 2\ngot  %d", len(objs))
+	}
+	generations := make(map[int64]bool)
+	for _, o := range objs {
+		if generations[o.Generation] {
+			t.Errorf("duplicate generation %d in versioned listing", o.Generation)
+		}
+		generations[o.Generation] = true
+	}
+}
+
 func TestBucketAttrsUpdateVersioning(t *testing.T) {
 	testForStorageBackends(t, func(t *testing.T, storage Storage) {
 		bucketName := "randombucket"

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -407,6 +407,9 @@ func (s *storageMemory) ComposeObject(bucketName string, objectNames []string, d
 	dest.Etag = ""
 	dest.Size = 0
 	dest.Metadata = metadata
+	// Compose creates a new generation rather than reusing the
+	// destination's, matching Cloud Storage.
+	dest.Generation = 0
 
 	result, err := s.CreateObject(dest.StreamingObject(), NoConditions{})
 	if err != nil {


### PR DESCRIPTION
ComposeObject reused the destination's generation, so composing over an existing object on a versioning-enabled bucket archived the old copy and stored the new one under the same generation: a versioned listing showed two entries sharing an id, and the archived copy was no longer addressable on its own.  Cloud Storage gives a compose result a new generation like any other write; zero the destination's so addObject mints one.