### PR TITLE
chore: fix formatting issues reported by golangci-lint v2.13.1

### DIFF
--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -167,10 +167,10 @@ func checkObjectAttrs(testObj Object, attrs *storage.ObjectAttrs, t *testing.T) 
 	if testObj.StorageClass != "" && attrs.StorageClass != testObj.StorageClass {
 		t.Errorf("wrong object storage class\nwant %q\ngot  %q", testObj.StorageClass, attrs.StorageClass)
 	}
-	if !(testObj.Created.IsZero()) && !testObj.Created.Equal(attrs.Created) {
+	if !testObj.Created.IsZero() && !testObj.Created.Equal(attrs.Created) {
 		t.Errorf("wrong created date\nwant %v\ngot   %v\nname %v", testObj.Created, attrs.Created, attrs.Name)
 	}
-	if !(testObj.Updated.IsZero()) && !testObj.Updated.Equal(attrs.Updated) {
+	if !testObj.Updated.IsZero() && !testObj.Updated.Equal(attrs.Updated) {
 		t.Errorf("wrong updated date\nwant %v\ngot   %v\nname %v", testObj.Updated, attrs.Updated, attrs.Name)
 	}
 	if testObj.Created.IsZero() && attrs.Created.IsZero() {

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -31,15 +31,17 @@ func makeStorageBackends(t *testing.T) (map[string]Storage, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return map[string]Storage{
-			"memory":     storageMemory,
-			"filesystem": storageFS,
-		}, func() {
-			err := os.RemoveAll(tempDir)
-			if err != nil {
-				t.Fatal(err)
-			}
+	backends := map[string]Storage{
+		"memory":     storageMemory,
+		"filesystem": storageFS,
+	}
+	cleanup := func() {
+		err := os.RemoveAll(tempDir)
+		if err != nil {
+			t.Fatal(err)
 		}
+	}
+	return backends, cleanup
 }
 
 func testForStorageBackends(t *testing.T, test func(t *testing.T, storage Storage)) {

--- a/internal/backend/object.go
+++ b/internal/backend/object.go
@@ -91,7 +91,7 @@ func (o *StreamingObject) BufferedObject() (Object, error) {
 }
 
 func (o *StreamingObject) patch(attrsToUpdate ObjectAttrs) {
-	currObjValues := reflect.ValueOf(&(o.ObjectAttrs)).Elem()
+	currObjValues := reflect.ValueOf(&o.ObjectAttrs).Elem()
 	currObjType := currObjValues.Type()
 	newObjValues := reflect.ValueOf(attrsToUpdate)
 	for i := 0; i < newObjValues.NumField(); i++ {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -89,7 +89,7 @@ func (g *Server) InsertObject(server pb.Storage_InsertObjectServer) error {
 	if err != nil {
 		return err
 	}
-	insert_obj_req := *(req.GetFirstMessage().(*pb.InsertObjectRequest_InsertObjectSpec))
+	insert_obj_req := *req.GetFirstMessage().(*pb.InsertObjectRequest_InsertObjectSpec)
 	validObject := backend.Object{
 		ObjectAttrs: backend.ObjectAttrs{
 			BucketName: insert_obj_req.InsertObjectSpec.Resource.Bucket,

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -27,12 +27,14 @@ func makeStorageBackends(t *testing.T) (map[string]backend.Storage, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return map[string]backend.Storage{
-			"memory":     storageMemory,
-			"filesystem": storageFS,
-		}, func() {
-			os.RemoveAll(tempDir)
-		}
+	backends := map[string]backend.Storage{
+		"memory":     storageMemory,
+		"filesystem": storageFS,
+	}
+	cleanup := func() {
+		os.RemoveAll(tempDir)
+	}
+	return backends, cleanup
 }
 
 func testForStorageBackends(t *testing.T, test func(t *testing.T, storage backend.Storage)) {


### PR DESCRIPTION
Fixes the lint failure on `main` ([run 32552329602](https://github.com/fsouza/fake-gcs-server/actions/runs/32552329602/job/96980984642)), which started after golangci-lint moved to v2.13.1.

- **gofumpt**: the newer version drops redundant parentheses around the operand of a unary/star expression — `!(x.IsZero())` → `!x.IsZero()`, `*(x.(*T))` → `*x.(*T)`, `&(o.ObjectAttrs)` → `&o.ObjectAttrs`.
- **gci vs. gofumpt in the `makeStorageBackends` helpers**: gofmt (and therefore gofumpt) adds an extra indentation level to multi-line results in a multi-value return, while gci's printer does not. The two formatters kept undoing each other, so no formatting of that return statement satisfied both. Hoisting the map and the cleanup closure into locals removes the construct and the conflict along with it.

`golangci-lint run` and `go test -race -vet all -mod readonly ./...` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)