### PR TITLE
fix: update ComposeObject test call for the new acl parameter

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -296,7 +296,7 @@ func TestComposeObjectNewGeneration(t *testing.T) {
 	noError(t, err)
 	source.Close()
 
-	composed, err := storage.ComposeObject(bucketName, []string{"source"}, "dest", nil, "text/plain", "", "", "", "", "")
+	composed, err := storage.ComposeObject(bucketName, []string{"source"}, "dest", nil, "text/plain", "", "", "", "", "", nil)
 	noError(t, err)
 	composed.Close()
 	if composed.Generation == dest.Generation {


### PR DESCRIPTION
`main` is red: [staticcheck](https://github.com/fsouza/fake-gcs-server/actions/runs/32554160473/job/96985613429) and the `tests` jobs both fail because `internal/backend` doesn't compile.

Semantic merge conflict between two PRs that were each green on their own:

- #2324 added `TestComposeObject`'s call to `storage.ComposeObject` with 10 arguments.
- #2310 added an 11th parameter, `acl []storage.ACLRule`, to the `Storage` interface.

Neither branch saw the other's change, so the breakage only appeared once both were on `main`. Passing `nil` matches how the neighbouring `metadata` argument is handled in the same call — the test isn't exercising ACLs.

Verified on this branch: `staticcheck ./...` clean, `golangci-lint run` reports 0 issues, and `go test -race -vet all -mod readonly ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)