### PR TITLE
Support pagination when listing buckets

### DIFF
--- a/fakestorage/bucket.go
+++ b/fakestorage/bucket.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
+	"strconv"
+	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/internal/backend"
@@ -139,11 +142,44 @@ func (s *Server) createBucketByPost(r *http.Request) jsonResponse {
 }
 
 func (s *Server) listBuckets(r *http.Request) jsonResponse {
+	var maxResults int
+	var err error
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		maxResults, err = strconv.Atoi(maxResultsStr)
+		if err != nil || maxResults < 0 {
+			return jsonResponse{
+				status:       http.StatusBadRequest,
+				errorMessage: fmt.Sprintf("invalid value for maxResults: %q", maxResultsStr),
+			}
+		}
+	}
 	buckets, err := s.backend.ListBuckets()
 	if err != nil {
 		return jsonResponse{errorMessage: err.Error()}
 	}
-	return jsonResponse{data: newListBucketsResponse(buckets, s.options.BucketsLocation, s.externalURL)}
+	slices.SortFunc(buckets, func(left, right backend.Bucket) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+	prefix := r.URL.Query().Get("prefix")
+	// The page token names the first bucket of the requested page, as the
+	// object listing's tokens do.
+	pageToken := r.URL.Query().Get("pageToken")
+	var respBuckets []backend.Bucket
+	for _, bucket := range buckets {
+		if !strings.HasPrefix(bucket.Name, prefix) {
+			continue
+		}
+		if pageToken != "" && bucket.Name < pageToken {
+			continue
+		}
+		respBuckets = append(respBuckets, bucket)
+	}
+	nextPageToken := ""
+	if maxResults > 0 && len(respBuckets) > maxResults {
+		nextPageToken = respBuckets[maxResults].Name
+		respBuckets = respBuckets[:maxResults]
+	}
+	return jsonResponse{data: newListBucketsResponse(respBuckets, s.options.BucketsLocation, s.externalURL, nextPageToken)}
 }
 
 func (s *Server) getBucket(r *http.Request) jsonResponse {

--- a/fakestorage/bucket_test.go
+++ b/fakestorage/bucket_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -411,6 +412,67 @@ func TestServerClientListBuckets(t *testing.T) {
 
 		if len(expectedBuckets) != numberOfBuckets {
 			t.Errorf("wrong number of buckets returned\nwant %d\ngot  %d", len(expectedBuckets), numberOfBuckets)
+		}
+	})
+}
+
+func TestServerClientListBucketsPaginated(t *testing.T) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
+		client := server.Client()
+		for _, name := range []string{"pager-bucket-c", "pager-bucket-a", "pager-bucket-b", "other-bucket"} {
+			if err := client.Bucket(name).Create(context.Background(), "whatever", nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		names := func(page []*storage.BucketAttrs) []string {
+			result := make([]string, len(page))
+			for i, attrs := range page {
+				result[i] = attrs.Name
+			}
+			return result
+		}
+		prefixed := func() *storage.BucketIterator {
+			it := client.Buckets(context.Background(), "whatever")
+			it.Prefix = "pager-bucket-"
+			return it
+		}
+
+		var firstPage []*storage.BucketAttrs
+		nextPageToken, err := iterator.NewPager(prefixed(), 2, "").NextPage(&firstPage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := []string{"pager-bucket-a", "pager-bucket-b"}; !reflect.DeepEqual(names(firstPage), want) {
+			t.Errorf("wrong first page\nwant %v\ngot  %v", want, names(firstPage))
+		}
+		if nextPageToken == "" {
+			t.Fatal("expected a nextPageToken while more buckets remain")
+		}
+
+		var secondPage []*storage.BucketAttrs
+		nextPageToken, err = iterator.NewPager(prefixed(), 2, nextPageToken).NextPage(&secondPage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := []string{"pager-bucket-c"}; !reflect.DeepEqual(names(secondPage), want) {
+			t.Errorf("wrong second page\nwant %v\ngot  %v", want, names(secondPage))
+		}
+		if nextPageToken != "" {
+			t.Errorf("unexpected nextPageToken after the last page: %q", nextPageToken)
+		}
+
+		// A page the listing exactly fills carries no token to a next one.
+		var exactPage []*storage.BucketAttrs
+		nextPageToken, err = iterator.NewPager(prefixed(), 3, "").NextPage(&exactPage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(exactPage) != 3 {
+			t.Errorf("wrong number of buckets returned\nwant 3\ngot  %d", len(exactPage))
+		}
+		if nextPageToken != "" {
+			t.Errorf("unexpected nextPageToken on an exactly-filled page: %q", nextPageToken)
 		}
 	})
 }

--- a/fakestorage/response.go
+++ b/fakestorage/response.go
@@ -29,10 +29,11 @@ type listResponse struct {
 	NextPageToken string   `json:"nextPageToken,omitempty"`
 }
 
-func newListBucketsResponse(buckets []backend.Bucket, location string, externalURL string) listResponse {
+func newListBucketsResponse(buckets []backend.Bucket, location string, externalURL string, nextPageToken string) listResponse {
 	resp := listResponse{
-		Kind:  "storage#buckets",
-		Items: make([]any, len(buckets)),
+		Kind:          "storage#buckets",
+		Items:         make([]any, len(buckets)),
+		NextPageToken: nextPageToken,
 	}
 	for i, bucket := range buckets {
 		resp.Items[i] = newBucketResponse(bucket, location, externalURL)


### PR DESCRIPTION
Listing buckets ignored maxResults, pageToken and prefix and answered in backend order: every bucket in one response, never a nextPageToken, so a paging client saw either everything at once or, with a real page size, results it had no way to continue.  Parse the three parameters and answer the way the object listing already does: buckets sort by name, the prefix filters, and when more remain past maxResults the nextPageToken names the first bucket of the next page.