### PR TITLE
perf: move an object to delete it instead of copying it

### DIFF
--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -78,17 +78,24 @@ func getNewGenerationIfZero(generation int64) int64 {
 	return generation
 }
 
-func (bm *bucketInMemory) deleteObject(obj Object, matchGeneration bool) {
-	index := findObject(obj, bm.activeObjects, matchGeneration)
+// deleteObject removes the named object, archiving it where the bucket keeps
+// versions, and reports whether the bucket held one.  It archives the object
+// the bucket stores rather than a copy of it, so a delete moves the content
+// between the two lists instead of duplicating it.
+func (bm *bucketInMemory) deleteObject(name string) bool {
+	wanted := Object{ObjectAttrs: ObjectAttrs{BucketName: bm.Name, Name: name}}
+	index := findObject(wanted, bm.activeObjects, false)
 	if index < 0 {
-		return
+		return false
 	}
+	obj := bm.activeObjects[index]
 	if bm.VersioningEnabled {
 		obj.Deleted = time.Now().Format(timestampFormat)
 		bm.mvToArchive(obj)
 	} else {
 		bm.deleteFromObjectList(obj, true)
 	}
+	return true
 }
 
 func (bm *bucketInMemory) cpToArchive(obj Object) {
@@ -320,21 +327,15 @@ func (s *storageMemory) GetObjectWithGeneration(bucketName, objectName string, g
 }
 
 func (s *storageMemory) DeleteObject(bucketName, objectName string) error {
-	obj, err := s.GetObject(bucketName, objectName)
-	if err != nil {
-		return err
-	}
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	bucketInMemory, err := s.getBucketInMemory(bucketName)
 	if err != nil {
 		return err
 	}
-	bufferedObject, err := obj.BufferedObject()
-	if err != nil {
-		return err
+	if !bucketInMemory.deleteObject(objectName) {
+		return errors.New("object not found")
 	}
-	bucketInMemory.deleteObject(bufferedObject, true)
 	s.buckets[bucketName] = bucketInMemory
 	return nil
 }


### PR DESCRIPTION
DeleteObject read the whole object into a fresh buffer with io.ReadAll before removing it, so deleting a 5 MiB object copied 5 MiB first: that delete cost 1.11ms where the 1 KiB one beside it cost 7.73us.  The copy served only to name the object, which its name does by itself, and to archive it where the bucket keeps versions, which the object the bucket already holds does better -- archiving that one moves the content from one list to the other rather than duplicating it.  Naming the object also spares a pass over the bucket: the delete now walks it to find the object and again to close the hole, where it used to walk it once more before either.

Deleting by name closes the window between the two locks the old path took, too.  It read under the read lock, released it, took the write lock, and then matched what it had read against what was there by generation; an object replaced in between failed that match, so the delete removed nothing and reported success.  DeleteObject now holds the write lock across the whole operation, and an object that is not there is an error rather than a silent no-op.

A delete costs the same whatever the object weighs.  With 50 objects in a bucket: 1 KiB 7.73us -> 3.72us, 1 MiB 254.47us -> 3.54us, 5 MiB 1.11ms -> 3.48us, and with versioning on 1.28ms -> 4.10us.  Over an s3-tests run against S3Proxy, 3753 deletes among 18413 requests and the same tests passing, the delete handler fell 0.66s -> 0.27s and its worst case 8.60ms -> 0.85ms.