### PR TITLE
Honor the generation parameter on object ACL endpoints

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -830,12 +830,27 @@ func (s *Server) deleteObject(r *http.Request) jsonResponse {
 	return jsonResponse{}
 }
 
-func (s *Server) listObjectACL(r *http.Request) jsonResponse {
+// objectForACLRequest resolves the object an ACL request addresses,
+// honoring its generation parameter the way object reads do.
+func (s *Server) objectForACLRequest(r *http.Request) (StreamingObject, *jsonResponse) {
 	vars := unescapeMuxVars(mux.Vars(r))
-
-	obj, err := s.GetObjectStreaming(vars["bucketName"], vars["objectName"])
+	obj, err := s.objectWithGenerationOnValidGeneration(vars["bucketName"], vars["objectName"], r.FormValue("generation"))
 	if err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+		statusCode := http.StatusNotFound
+		var errMessage string
+		if errors.Is(err, errInvalidGeneration) {
+			statusCode = http.StatusBadRequest
+			errMessage = err.Error()
+		}
+		return StreamingObject{}, &jsonResponse{status: statusCode, errorMessage: errMessage}
+	}
+	return obj, nil
+}
+
+func (s *Server) listObjectACL(r *http.Request) jsonResponse {
+	obj, errResponse := s.objectForACLRequest(r)
+	if errResponse != nil {
+		return *errResponse
 	}
 	defer obj.Close()
 
@@ -845,9 +860,9 @@ func (s *Server) listObjectACL(r *http.Request) jsonResponse {
 func (s *Server) deleteObjectACL(r *http.Request) jsonResponse {
 	vars := unescapeMuxVars(mux.Vars(r))
 
-	obj, err := s.GetObjectStreaming(vars["bucketName"], vars["objectName"])
-	if err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+	obj, errResponse := s.objectForACLRequest(r)
+	if errResponse != nil {
+		return *errResponse
 	}
 	defer obj.Close()
 	entity := vars["entity"]
@@ -860,7 +875,7 @@ func (s *Server) deleteObjectACL(r *http.Request) jsonResponse {
 	}
 
 	obj.ACL = newAcls
-	obj, err = s.createObject(obj, backend.NoConditions{})
+	obj, err := s.createObject(obj, backend.NoConditions{})
 	if err != nil {
 		return errToJsonResponse(err)
 	}
@@ -872,9 +887,9 @@ func (s *Server) deleteObjectACL(r *http.Request) jsonResponse {
 func (s *Server) getObjectACL(r *http.Request) jsonResponse {
 	vars := unescapeMuxVars(mux.Vars(r))
 
-	obj, err := s.backend.GetObject(vars["bucketName"], vars["objectName"])
-	if err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+	obj, errResponse := s.objectForACLRequest(r)
+	if errResponse != nil {
+		return *errResponse
 	}
 	defer obj.Close()
 	entity := vars["entity"]
@@ -896,11 +911,9 @@ func (s *Server) getObjectACL(r *http.Request) jsonResponse {
 }
 
 func (s *Server) setObjectACL(r *http.Request) jsonResponse {
-	vars := unescapeMuxVars(mux.Vars(r))
-
-	obj, err := s.GetObjectStreaming(vars["bucketName"], vars["objectName"])
-	if err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+	obj, errResponse := s.objectForACLRequest(r)
+	if errResponse != nil {
+		return *errResponse
 	}
 	defer obj.Close()
 
@@ -924,7 +937,7 @@ func (s *Server) setObjectACL(r *http.Request) jsonResponse {
 		Role:   role,
 	}}
 
-	obj, err = s.createObject(obj, backend.NoConditions{})
+	obj, err := s.createObject(obj, backend.NoConditions{})
 	if err != nil {
 		return errToJsonResponse(err)
 	}

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1826,6 +1826,100 @@ func TestServerClientObjectDeleteErrors(t *testing.T) {
 	})
 }
 
+// The Go client operates on the latest generation only ("Selecting a
+// specific generation of an object is not currently supported by the
+// client"), so this test drives the JSON API's generation parameter
+// directly.
+func TestServerClientObjectACLWithGeneration(t *testing.T) {
+	runServersTest(t, runServersOptions{}, func(t *testing.T, server *Server) {
+		const bucketName = "some-bucket-with-ver"
+		const objectName = "per-generation-acl.txt"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName, VersioningEnabled: true})
+		server.CreateObject(Object{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName, Generation: 1111},
+			Content:     []byte("first"),
+		})
+		server.CreateObject(Object{
+			ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: objectName, Generation: 2222},
+			Content:     []byte("second"),
+		})
+
+		client := server.HTTPClient()
+		aclURL := server.URL() + "/storage/v1/b/" + bucketName + "/o/" + objectName + "/acl"
+		do := func(method, url string, body io.Reader) int {
+			t.Helper()
+			req, err := http.NewRequest(method, url, body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if body != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			return resp.StatusCode
+		}
+		listACL := func(query string) int {
+			t.Helper()
+			resp, err := client.Get(aclURL + query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("unexpected status listing acl: %d", resp.StatusCode)
+			}
+			var data struct {
+				Items []any `json:"items"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+				t.Fatal(err)
+			}
+			return len(data.Items)
+		}
+
+		t.Log("setting an acl on the archived generation")
+		payload := strings.NewReader(`{"entity": "allUsers", "role": "READER"}`)
+		if status := do(http.MethodPut, aclURL+"/allUsers?generation=1111", payload); status != http.StatusOK {
+			t.Fatalf("unexpected status setting acl: %d", status)
+		}
+
+		if rules := listACL("?generation=1111"); rules != 1 {
+			t.Errorf("wrong acl on the archived generation\nwant 1 rule\ngot  %d", rules)
+		}
+		if rules := listACL(""); rules != 0 {
+			t.Errorf("setting the archived generation's acl changed the live object's: %d rules", rules)
+		}
+
+		t.Log("the live object and the version count are untouched")
+		obj, err := server.GetObject(bucketName, objectName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obj.Generation != 2222 || string(obj.Content) != "second" {
+			t.Errorf("live object changed: generation %d content %q", obj.Generation, obj.Content)
+		}
+		objs, _, err := server.ListObjectsWithOptions(bucketName, ListOptions{Versions: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(objs) != 2 {
+			t.Errorf("wrong number of versions after acl update\nwant 2\ngot  %d", len(objs))
+		}
+
+		t.Log("deleting the archived generation's acl")
+		if status := do(http.MethodDelete, aclURL+"/allUsers?generation=1111", nil); status != http.StatusOK {
+			t.Fatalf("unexpected status deleting acl: %d", status)
+		}
+		if rules := listACL("?generation=1111"); rules != 0 {
+			t.Errorf("acl survived deletion: %d rules", rules)
+		}
+	})
+}
+
 func TestServerClientObjectSetAclPrivate(t *testing.T) {
 	objs := []Object{
 		{ObjectAttrs: ObjectAttrs{BucketName: "some-bucket", Name: "img/public-to-private.jpg"}},

--- a/internal/backend/memory.go
+++ b/internal/backend/memory.go
@@ -54,12 +54,20 @@ func (bm *bucketInMemory) addObject(obj Object) Object {
 		obj.StorageClass = "STANDARD"
 	}
 	obj.Generation = getNewGenerationIfZero(obj.Generation)
+	// A write that names an existing generation is a metadata update
+	// (PatchObject, ACL changes) rather than a new version: it replaces
+	// that generation in place wherever it lives, archiving nothing.
+	if index := findObject(obj, bm.activeObjects, true); index >= 0 {
+		bm.activeObjects[index] = obj
+		return obj
+	}
+	if index := findObject(obj, bm.archivedObjects, true); index >= 0 {
+		bm.archivedObjects[index] = obj
+		return obj
+	}
 	index := findObject(obj, bm.activeObjects, false)
 	if index >= 0 {
-		// A write that reuses the live generation is a metadata update
-		// (PatchObject, the ACL handlers) rather than a new version; only
-		// a write that changes the generation archives the old one.
-		if bm.VersioningEnabled && bm.activeObjects[index].Generation != obj.Generation {
+		if bm.VersioningEnabled {
 			bm.activeObjects[index].Deleted = time.Now().Format(timestampFormat)
 			bm.cpToArchive(bm.activeObjects[index])
 		}


### PR DESCRIPTION
The four object ACL handlers resolved the live object whatever generation the caller named, so a per-version ACL read answered with the live version's grants and a per-version write changed them. Resolve the addressed generation the way object reads do, and extend the memory backend's in-place update to archived generations, so persisting a noncurrent version's ACL updates that version rather than overwriting the live object with it.