### PR TITLE
Honor object preconditions outside the upload path

### DIFF
--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -808,12 +808,16 @@ func (s *Server) deleteObject(r *http.Request) jsonResponse {
 	// Calling Close before checking err is okay on objects, and the object
 	// may need to be closed whether or not there's an error.
 	defer obj.Close() //lint:ignore SA5001 // see above
-	if err == nil {
-		if generation > 0 {
-			err = s.backend.DeleteObjectWithGeneration(vars["bucketName"], vars["objectName"], generation)
-		} else {
-			err = s.backend.DeleteObject(vars["bucketName"], vars["objectName"])
-		}
+	if err != nil {
+		return jsonResponse{status: http.StatusNotFound}
+	}
+	if errResponse := s.checkPreconditions(r, vars["bucketName"], vars["objectName"]); errResponse != nil {
+		return *errResponse
+	}
+	if generation > 0 {
+		err = s.backend.DeleteObjectWithGeneration(vars["bucketName"], vars["objectName"], generation)
+	} else {
+		err = s.backend.DeleteObject(vars["bucketName"], vars["objectName"])
 	}
 	if err != nil {
 		return jsonResponse{status: http.StatusNotFound}
@@ -973,6 +977,21 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 		return jsonResponse{errorMessage: errMessage, status: statusCode}
 	}
 
+	// The ifSourceGenerationMatch family guards the object being read, the
+	// plain one the object being written; a rewrite is the only request that
+	// can name both.
+	sourceConditions, err := parsePreconditions(r.URL.Query(), "Source")
+	if err != nil {
+		return jsonResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
+	}
+	if !sourceConditions.ConditionsMet(obj.Generation) {
+		return errToJsonResponse(backend.PreConditionFailed)
+	}
+	destinationConditions, err := parsePreconditions(r.URL.Query(), "")
+	if err != nil {
+		return jsonResponse{errorMessage: err.Error(), status: http.StatusBadRequest}
+	}
+
 	var metadata multipartMetadata
 	err = json.NewDecoder(r.Body).Decode(&metadata)
 	if err != nil && err != io.EOF { // The body is optional
@@ -1026,7 +1045,7 @@ func (s *Server) rewriteObject(r *http.Request) jsonResponse {
 		Content: obj.Content,
 	}
 
-	created, err := s.createObject(newObject, backend.NoConditions{})
+	created, err := s.createObject(newObject, destinationConditions)
 	if err != nil {
 		return errToJsonResponse(err)
 	}
@@ -1359,6 +1378,10 @@ func (s *Server) patchObject(r *http.Request) jsonResponse {
 		}
 	}
 
+	if errResponse := s.checkPreconditions(r, bucketName, objectName); errResponse != nil {
+		return *errResponse
+	}
+
 	backendObj, err := s.backend.PatchObject(bucketName, objectName, attrsToUpdate)
 	if err != nil {
 		return jsonResponse{
@@ -1426,6 +1449,10 @@ func (s *Server) updateObject(r *http.Request) jsonResponse {
 			attrsToUpdate.ACL = append(attrsToUpdate.ACL, newAcl)
 		}
 	}
+	if errResponse := s.checkPreconditions(r, bucketName, objectName); errResponse != nil {
+		return *errResponse
+	}
+
 	backendObj, err := s.backend.UpdateObject(bucketName, objectName, attrsToUpdate)
 	if err != nil {
 		return jsonResponse{
@@ -1488,6 +1515,10 @@ func (s *Server) composeObject(r *http.Request) jsonResponse {
 	if predefinedACL := r.URL.Query().Get(
 		"destinationPredefinedAcl"); predefinedACL != "" {
 		acl = getObjectACL(predefinedACL)
+	}
+
+	if errResponse := s.checkPreconditions(r, bucketName, destinationObject); errResponse != nil {
+		return *errResponse
 	}
 
 	backendObj, err := s.backend.ComposeObject(bucketName, sourceNames, destinationObject, composeRequest.Destination.Metadata, composeRequest.Destination.ContentType, composeRequest.Destination.ContentEncoding, composeRequest.Destination.ContentDisposition, composeRequest.Destination.ContentLanguage, composeRequest.Destination.CacheControl, composeRequest.Destination.StorageClass, acl)

--- a/fakestorage/preconditions.go
+++ b/fakestorage/preconditions.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Francisco Souza. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fakestorage
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/fsouza/fake-gcs-server/internal/backend"
+)
+
+// objectMetageneration is the metageneration every object reports; see
+// newObjectResponse. Nothing here revises an object's metadata without
+// minting a new one, so the value never moves and a condition naming any
+// other value cannot hold.
+const objectMetageneration = 1
+
+// preconditions holds the ifGenerationMatch family a request may name. GCS
+// evaluates them against the object the request addresses and answers 412
+// when one does not hold, generation zero standing for an object that is not
+// there -- which is how a caller asks to create one and no more.
+type preconditions struct {
+	ifGenerationMatch        *int64
+	ifGenerationNotMatch     *int64
+	ifMetagenerationMatch    *int64
+	ifMetagenerationNotMatch *int64
+}
+
+// empty reports whether the request named no condition at all, letting a
+// caller skip the lookup the check would otherwise need.
+func (p preconditions) empty() bool {
+	return p == preconditions{}
+}
+
+// ConditionsMet reports whether every condition holds for an object of the
+// given generation, zero meaning none. It satisfies backend.Conditions, so
+// the paths that create an object can hand it down and have it answered where
+// the object is published rather than a moment beforehand.
+func (p preconditions) ConditionsMet(activeGeneration int64) bool {
+	if p.ifGenerationMatch != nil && *p.ifGenerationMatch != activeGeneration {
+		return false
+	}
+	if p.ifGenerationNotMatch != nil && *p.ifGenerationNotMatch == activeGeneration {
+		return false
+	}
+	if activeGeneration == 0 {
+		// An object that is not there has no metadata to have a generation of.
+		return true
+	}
+	if p.ifMetagenerationMatch != nil && *p.ifMetagenerationMatch != objectMetageneration {
+		return false
+	}
+	if p.ifMetagenerationNotMatch != nil && *p.ifMetagenerationNotMatch == objectMetageneration {
+		return false
+	}
+	return true
+}
+
+// parsePreconditions reads the conditions a request names. The prefix picks
+// which family: empty for the ifGenerationMatch naming the object being
+// written, "Source" for the ifSourceGenerationMatch a copy or a rewrite names
+// for the object it reads.
+func parsePreconditions(query url.Values, prefix string) (preconditions, error) {
+	var result preconditions
+	for _, condition := range []struct {
+		name string
+		dest **int64
+	}{
+		{"if" + prefix + "GenerationMatch", &result.ifGenerationMatch},
+		{"if" + prefix + "GenerationNotMatch", &result.ifGenerationNotMatch},
+		{"if" + prefix + "MetagenerationMatch", &result.ifMetagenerationMatch},
+		{"if" + prefix + "MetagenerationNotMatch", &result.ifMetagenerationNotMatch},
+	} {
+		value := query.Get(condition.name)
+		if value == "" {
+			continue
+		}
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return preconditions{}, fmt.Errorf("invalid %s: %w", condition.name, err)
+		}
+		*condition.dest = &parsed
+	}
+	return result, nil
+}
+
+// checkPreconditions answers the conditions a request names against the live
+// object at bucketName/objectName, one that is not there counting as
+// generation zero. It returns nil when they all hold and the response to send
+// when one does not.
+func (s *Server) checkPreconditions(r *http.Request, bucketName, objectName string) *jsonResponse {
+	conditions, err := parsePreconditions(r.URL.Query(), "")
+	if err != nil {
+		return &jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
+	}
+	if conditions.empty() {
+		return nil
+	}
+	var generation int64
+	if obj, err := s.backend.GetObject(bucketName, objectName); err == nil {
+		generation = obj.Generation
+		obj.Close()
+	}
+	if !conditions.ConditionsMet(generation) {
+		response := errToJsonResponse(backend.PreConditionFailed)
+		return &response
+	}
+	return nil
+}

--- a/fakestorage/preconditions_test.go
+++ b/fakestorage/preconditions_test.go
@@ -1,0 +1,345 @@
+// Copyright 2026 Francisco Souza. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fakestorage
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+)
+
+func assertPreconditionFailed(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the precondition to fail, got no error")
+	}
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected a googleapi error, got %v", err)
+	}
+	if apiErr.Code != http.StatusPreconditionFailed {
+		t.Errorf("wrong status\nwant %d\ngot  %d", http.StatusPreconditionFailed, apiErr.Code)
+	}
+}
+
+// seedObject puts an object with known content and hands back a handle on it
+// along with the generation it was created at.
+func seedObject(t *testing.T, server *Server, bucketName, name string) (*storage.ObjectHandle, int64) {
+	t.Helper()
+	server.CreateObject(Object{
+		ObjectAttrs: ObjectAttrs{BucketName: bucketName, Name: name, ContentType: "text/plain"},
+		Content:     []byte("some content"),
+	})
+	handle := server.Client().Bucket(bucketName).Object(name)
+	attrs, err := handle.Attrs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle, attrs.Generation
+}
+
+func TestServerObjectDeletePreconditions(t *testing.T) {
+	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
+		const bucketName = "some-bucket"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		ctx := context.Background()
+
+		t.Run("generation that does not match", func(t *testing.T) {
+			handle, generation := seedObject(t, server, bucketName, "delete-wrong-generation.txt")
+			err := handle.If(storage.Conditions{GenerationMatch: generation + 1}).Delete(ctx)
+			assertPreconditionFailed(t, err)
+			if _, err := handle.Attrs(ctx); err != nil {
+				t.Errorf("object went away despite the failed precondition: %v", err)
+			}
+		})
+
+		t.Run("generation that matches", func(t *testing.T) {
+			handle, generation := seedObject(t, server, bucketName, "delete-right-generation.txt")
+			if err := handle.If(storage.Conditions{GenerationMatch: generation}).Delete(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := handle.Attrs(ctx); !errors.Is(err, storage.ErrObjectNotExist) {
+				t.Errorf("object outlived a delete its precondition allowed: %v", err)
+			}
+		})
+
+		t.Run("metageneration that does not match", func(t *testing.T) {
+			handle, _ := seedObject(t, server, bucketName, "delete-wrong-metageneration.txt")
+			err := handle.If(storage.Conditions{MetagenerationMatch: objectMetageneration + 1}).Delete(ctx)
+			assertPreconditionFailed(t, err)
+			if _, err := handle.Attrs(ctx); err != nil {
+				t.Errorf("object went away despite the failed precondition: %v", err)
+			}
+		})
+
+		t.Run("generation that must not match", func(t *testing.T) {
+			handle, generation := seedObject(t, server, bucketName, "delete-generation-not-match.txt")
+			err := handle.If(storage.Conditions{GenerationNotMatch: generation}).Delete(ctx)
+			assertPreconditionFailed(t, err)
+			if _, err := handle.Attrs(ctx); err != nil {
+				t.Errorf("object went away despite the failed precondition: %v", err)
+			}
+		})
+	})
+}
+
+func TestServerObjectUpdatePreconditions(t *testing.T) {
+	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
+		const bucketName = "some-bucket"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		ctx := context.Background()
+		update := storage.ObjectAttrsToUpdate{ContentType: "application/json"}
+
+		t.Run("metageneration that does not match", func(t *testing.T) {
+			handle, _ := seedObject(t, server, bucketName, "update-wrong-metageneration.txt")
+			_, err := handle.If(storage.Conditions{
+				MetagenerationMatch: objectMetageneration + 1,
+			}).Update(ctx, update)
+			assertPreconditionFailed(t, err)
+			attrs, err := handle.Attrs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attrs.ContentType != "text/plain" {
+				t.Errorf("object was updated despite the failed precondition: content type is %q", attrs.ContentType)
+			}
+		})
+
+		t.Run("metageneration that matches", func(t *testing.T) {
+			handle, _ := seedObject(t, server, bucketName, "update-right-metageneration.txt")
+			attrs, err := handle.If(storage.Conditions{
+				MetagenerationMatch: objectMetageneration,
+			}).Update(ctx, update)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attrs.ContentType != "application/json" {
+				t.Errorf("wrong content type\nwant %q\ngot  %q", "application/json", attrs.ContentType)
+			}
+		})
+
+		t.Run("generation that does not match", func(t *testing.T) {
+			handle, generation := seedObject(t, server, bucketName, "update-wrong-generation.txt")
+			_, err := handle.If(storage.Conditions{GenerationMatch: generation + 1}).Update(ctx, update)
+			assertPreconditionFailed(t, err)
+		})
+	})
+}
+
+func TestServerObjectCopyPreconditions(t *testing.T) {
+	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
+		const bucketName = "some-bucket"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		ctx := context.Background()
+		bucket := server.Client().Bucket(bucketName)
+
+		t.Run("source generation that does not match", func(t *testing.T) {
+			source, generation := seedObject(t, server, bucketName, "copy-source-wrong.txt")
+			destination := bucket.Object("copy-source-wrong-destination.txt")
+			_, err := destination.CopierFrom(
+				source.If(storage.Conditions{GenerationMatch: generation + 1})).Run(ctx)
+			assertPreconditionFailed(t, err)
+			if _, err := destination.Attrs(ctx); !errors.Is(err, storage.ErrObjectNotExist) {
+				t.Errorf("destination was written despite the failed precondition: %v", err)
+			}
+		})
+
+		t.Run("destination generation that does not match", func(t *testing.T) {
+			source, _ := seedObject(t, server, bucketName, "copy-destination-wrong-source.txt")
+			destination, generation := seedObject(t, server, bucketName, "copy-destination-wrong.txt")
+			_, err := destination.If(storage.Conditions{
+				GenerationMatch: generation + 1,
+			}).CopierFrom(source).Run(ctx)
+			assertPreconditionFailed(t, err)
+		})
+
+		t.Run("destination that must not exist but does", func(t *testing.T) {
+			source, _ := seedObject(t, server, bucketName, "copy-exists-source.txt")
+			destination, _ := seedObject(t, server, bucketName, "copy-exists-destination.txt")
+			_, err := destination.If(storage.Conditions{
+				DoesNotExist: true,
+			}).CopierFrom(source).Run(ctx)
+			assertPreconditionFailed(t, err)
+		})
+
+		t.Run("conditions that hold", func(t *testing.T) {
+			source, sourceGeneration := seedObject(t, server, bucketName, "copy-ok-source.txt")
+			destination := bucket.Object("copy-ok-destination.txt")
+			_, err := destination.If(storage.Conditions{DoesNotExist: true}).CopierFrom(
+				source.If(storage.Conditions{GenerationMatch: sourceGeneration})).Run(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := destination.Attrs(ctx); err != nil {
+				t.Errorf("destination was not written though its preconditions held: %v", err)
+			}
+		})
+	})
+}
+
+func TestServerObjectComposePreconditions(t *testing.T) {
+	runServersTest(t, runServersOptions{enableFSBackend: true}, func(t *testing.T, server *Server) {
+		const bucketName = "some-bucket"
+		server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+		ctx := context.Background()
+		bucket := server.Client().Bucket(bucketName)
+		first, _ := seedObject(t, server, bucketName, "compose-source-1.txt")
+		second, _ := seedObject(t, server, bucketName, "compose-source-2.txt")
+
+		t.Run("generation that does not match", func(t *testing.T) {
+			destination, generation := seedObject(t, server, bucketName, "compose-wrong-generation.txt")
+			_, err := destination.If(storage.Conditions{
+				GenerationMatch: generation + 1,
+			}).ComposerFrom(first, second).Run(ctx)
+			assertPreconditionFailed(t, err)
+			attrs, err := destination.Attrs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attrs.Generation != generation {
+				t.Errorf("destination was composed despite the failed precondition")
+			}
+		})
+
+		t.Run("destination that must not exist but does", func(t *testing.T) {
+			destination, _ := seedObject(t, server, bucketName, "compose-exists.txt")
+			_, err := destination.If(storage.Conditions{
+				DoesNotExist: true,
+			}).ComposerFrom(first, second).Run(ctx)
+			assertPreconditionFailed(t, err)
+		})
+
+		t.Run("destination that must not exist and does not", func(t *testing.T) {
+			destination := bucket.Object("compose-new.txt")
+			composer := destination.If(storage.Conditions{DoesNotExist: true}).ComposerFrom(first, second)
+			composer.ContentType = "text/plain"
+			if _, err := composer.Run(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := destination.Attrs(ctx); err != nil {
+				t.Errorf("destination was not composed though its precondition held: %v", err)
+			}
+		})
+	})
+}
+
+func TestParsePreconditions(t *testing.T) {
+	generation := func(value int64) *int64 { return &value }
+	tests := []struct {
+		name   string
+		query  string
+		prefix string
+		want   preconditions
+	}{
+		{"nothing named", "", "", preconditions{}},
+		{
+			"the whole family",
+			"ifGenerationMatch=1&ifGenerationNotMatch=2&ifMetagenerationMatch=3&ifMetagenerationNotMatch=4",
+			"",
+			preconditions{
+				ifGenerationMatch:        generation(1),
+				ifGenerationNotMatch:     generation(2),
+				ifMetagenerationMatch:    generation(3),
+				ifMetagenerationNotMatch: generation(4),
+			},
+		},
+		{
+			"the source family, which the plain prefix must not see",
+			"ifSourceGenerationMatch=5&ifGenerationMatch=6",
+			"Source",
+			preconditions{ifGenerationMatch: generation(5)},
+		},
+		{
+			"the plain family, which the source prefix must not see",
+			"ifSourceGenerationMatch=5&ifGenerationMatch=6",
+			"",
+			preconditions{ifGenerationMatch: generation(6)},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, err := url.ParseQuery(test.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := parsePreconditions(query, test.prefix)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertSameConditions(t, test.want, got)
+		})
+	}
+
+	t.Run("a value that is not a number", func(t *testing.T) {
+		query, err := url.ParseQuery("ifGenerationMatch=notanumber")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := parsePreconditions(query, ""); err == nil {
+			t.Error("expected a malformed condition to be rejected")
+		}
+	})
+}
+
+func assertSameConditions(t *testing.T, want, got preconditions) {
+	t.Helper()
+	for _, field := range []struct {
+		name string
+		want *int64
+		got  *int64
+	}{
+		{"ifGenerationMatch", want.ifGenerationMatch, got.ifGenerationMatch},
+		{"ifGenerationNotMatch", want.ifGenerationNotMatch, got.ifGenerationNotMatch},
+		{"ifMetagenerationMatch", want.ifMetagenerationMatch, got.ifMetagenerationMatch},
+		{"ifMetagenerationNotMatch", want.ifMetagenerationNotMatch, got.ifMetagenerationNotMatch},
+	} {
+		switch {
+		case field.want == nil && field.got == nil:
+		case field.want == nil || field.got == nil:
+			t.Errorf("%s: want %v, got %v", field.name, field.want, field.got)
+		case *field.want != *field.got:
+			t.Errorf("%s: want %d, got %d", field.name, *field.want, *field.got)
+		}
+	}
+}
+
+func TestPreconditionsConditionsMet(t *testing.T) {
+	value := func(v int64) *int64 { return &v }
+	tests := []struct {
+		name       string
+		conditions preconditions
+		generation int64
+		want       bool
+	}{
+		{"nothing named", preconditions{}, 7, true},
+		{"generation matches", preconditions{ifGenerationMatch: value(7)}, 7, true},
+		{"generation differs", preconditions{ifGenerationMatch: value(8)}, 7, false},
+		{"must not exist and does not", preconditions{ifGenerationMatch: value(0)}, 0, true},
+		{"must not exist but does", preconditions{ifGenerationMatch: value(0)}, 7, false},
+		{"generation must differ and does", preconditions{ifGenerationNotMatch: value(8)}, 7, true},
+		{"generation must differ but matches", preconditions{ifGenerationNotMatch: value(7)}, 7, false},
+		{"metageneration matches", preconditions{ifMetagenerationMatch: value(objectMetageneration)}, 7, true},
+		{"metageneration differs", preconditions{ifMetagenerationMatch: value(objectMetageneration + 1)}, 7, false},
+		{"metageneration must differ but matches", preconditions{ifMetagenerationNotMatch: value(objectMetageneration)}, 7, false},
+		{
+			"an absent object has no metageneration to compare",
+			preconditions{ifMetagenerationMatch: value(objectMetageneration + 1)},
+			0,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.conditions.ConditionsMet(test.generation); got != test.want {
+				t.Errorf("wrong answer for generation %d\nwant %v\ngot  %v", test.generation, test.want, got)
+			}
+		})
+	}
+}

--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -104,21 +104,6 @@ type resumableUploadBody struct {
 	PredefinedACL      string            `json:"predefinedAcl"`
 }
 
-type generationCondition struct {
-	ifGenerationMatch    *int64
-	ifGenerationNotMatch *int64
-}
-
-func (c generationCondition) ConditionsMet(activeGeneration int64) bool {
-	if c.ifGenerationMatch != nil && *c.ifGenerationMatch != activeGeneration {
-		return false
-	}
-	if c.ifGenerationNotMatch != nil && *c.ifGenerationNotMatch == activeGeneration {
-		return false
-	}
-	return true
-}
-
 // resumableUploadEntry holds the in-progress object for a resumable upload
 // session along with state supplied when the session was initiated but only
 // applied when the upload is finalized: generation preconditions (e.g.
@@ -127,7 +112,7 @@ func (c generationCondition) ConditionsMet(activeGeneration int64) bool {
 // so they must be carried across both requests.
 type resumableUploadEntry struct {
 	obj            Object
-	conditions     generationCondition
+	conditions     preconditions
 	declaredMd5    string
 	declaredCrc32c string
 }
@@ -243,7 +228,7 @@ func (s *Server) handleBodyBasedResumableUpload(r *http.Request, body *resumable
 		},
 	}
 
-	conditions, err := s.wrapUploadPreconditions(r, bucketName, body.Name)
+	conditions, err := parsePreconditions(r.URL.Query(), "")
 	if err != nil {
 		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
 	}
@@ -414,34 +399,6 @@ func (s *Server) insertFormObject(r *http.Request) xmlResponse {
 	return xmlResponse{status: successActionStatus}
 }
 
-func (s *Server) wrapUploadPreconditions(r *http.Request, bucketName string, objectName string) (generationCondition, error) {
-	result := generationCondition{
-		ifGenerationMatch:    nil,
-		ifGenerationNotMatch: nil,
-	}
-	ifGenerationMatch := r.URL.Query().Get("ifGenerationMatch")
-
-	if ifGenerationMatch != "" {
-		gen, err := strconv.ParseInt(ifGenerationMatch, 10, 64)
-		if err != nil {
-			return generationCondition{}, err
-		}
-		result.ifGenerationMatch = &gen
-	}
-
-	ifGenerationNotMatch := r.URL.Query().Get("ifGenerationNotMatch")
-
-	if ifGenerationNotMatch != "" {
-		gen, err := strconv.ParseInt(ifGenerationNotMatch, 10, 64)
-		if err != nil {
-			return generationCondition{}, err
-		}
-		result.ifGenerationNotMatch = &gen
-	}
-
-	return result, nil
-}
-
 func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 	defer r.Body.Close()
 	name := r.URL.Query().Get("name")
@@ -463,7 +420,7 @@ func (s *Server) simpleUpload(bucketName string, r *http.Request) jsonResponse {
 		}
 	}
 
-	conditions, err := s.wrapUploadPreconditions(r, bucketName, name)
+	conditions, err := parsePreconditions(r.URL.Query(), "")
 	if err != nil {
 		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
 	}
@@ -606,7 +563,7 @@ func (s *Server) multipartUpload(bucketName string, r *http.Request) jsonRespons
 		contentEncoding = metadata.ContentEncoding
 	}
 
-	conditions, err := s.wrapUploadPreconditions(r, bucketName, objName)
+	conditions, err := parsePreconditions(r.URL.Query(), "")
 	if err != nil {
 		return jsonResponse{
 			status:       http.StatusBadRequest,
@@ -674,7 +631,7 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 	if contentEncoding == "" {
 		contentEncoding = metadata.ContentEncoding
 	}
-	conditions, err := s.wrapUploadPreconditions(r, bucketName, objName)
+	conditions, err := parsePreconditions(r.URL.Query(), "")
 	if err != nil {
 		return jsonResponse{status: http.StatusBadRequest, errorMessage: err.Error()}
 	}


### PR DESCRIPTION
The ifGenerationMatch family was answered only where an upload creates an object.  Delete, patch, update, rewrite, copy and compose parsed no preconditions at all, so a caller guarding a mutation against the generation it had just read was told the mutation succeeded whatever the object had become in between -- silently, since a condition the server never reads cannot fail.  Real GCS answers 412 to every one of them.

Move the parsing out of the upload path into a preconditions type that reads the whole family, ifMetagenerationMatch included, and the source family a rewrite names for the object it reads rather than the one it writes.  A rewrite's destination conditions go on to the backend the way an upload's already do, so they are answered where the object is published; the rest are answered against the live object the request is about to change.  Metageneration is compared against the 1 that every object here reports, since nothing revises metadata without minting a new object.