### PR TITLE
fix(fakestorage): return 400 for invalid matchGlob patterns

### DIFF
--- a/fakestorage/matchglob.go
+++ b/fakestorage/matchglob.go
@@ -1,0 +1,151 @@
+package fakestorage
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// invalidMatchGlobMessage returns the error message that the GCS JSON API
+// returns for an invalid matchGlob pattern, or "" when the pattern is valid.
+// The messages are returned verbatim, so callers can put them on the wire.
+//
+// The rules and messages come from probing live GCS (JSON API, 2026-08-24/25):
+//
+//   - '\' escapes the next character anywhere; a trailing '\' is accepted.
+//   - ']' or '}' without a matching opener is an error.
+//   - Braces must balance. An unclosed '{' reports the innermost one.
+//   - A character class must be closed and must have at least one member.
+//     A leading '!' or '^' negates the class and does not count as a member.
+//   - Inside a class, '[' and '{' must be escaped. So must '}', and ','
+//     while a brace expansion is open; unescaped, they abort the class.
+//   - Ranges inside a class must be ascending and compare by code point.
+//   - Patterns need not be valid UTF-8. Live GCS decodes invalid bytes to
+//     U+FFFD, as DecodeRuneInString does here: [\xFF-\xFE] is accepted as
+//     an equal-endpoint range, and a range error renders the replacement
+//     character in the message.
+//
+// Indexes in the messages are byte offsets, as on live GCS.
+func invalidMatchGlobMessage(pattern string) string {
+	var braceStack []int
+	for i := 0; i < len(pattern); {
+		r, size := utf8.DecodeRuneInString(pattern[i:])
+		switch r {
+		case '\\':
+			i += size
+			if i < len(pattern) {
+				_, escSize := utf8.DecodeRuneInString(pattern[i:])
+				i += escSize
+			}
+			continue
+		case '[':
+			next, msg := scanMatchGlobClass(pattern, i, len(braceStack) > 0)
+			if msg != "" {
+				return msg
+			}
+			i = next
+			continue
+		case ']':
+			return fmt.Sprintf("Glob pattern had closing character class ']' at index %d without any previous opening '['. Either add an opening '[' or use '\\]' to match ']'.", i)
+		case '{':
+			braceStack = append(braceStack, i)
+		case '}':
+			if len(braceStack) == 0 {
+				return bareClosingBraceMessage(i)
+			}
+			braceStack = braceStack[:len(braceStack)-1]
+		}
+		i += size
+	}
+	if len(braceStack) > 0 {
+		return fmt.Sprintf("Glob pattern brace expansion opening '{' at index %d has no closing '}'. Use '\\{' to match a literal '{'.", braceStack[len(braceStack)-1])
+	}
+	return ""
+}
+
+// scanMatchGlobClass validates the character class that opens at
+// pattern[start] and returns the byte offset just past its closing ']'.
+// On an invalid class it returns the GCS error message instead.
+// inBraces reports whether a brace expansion is open at the class: GCS
+// aborts a class on the characters that would end a brace arm (',' and
+// '}') only in that context.
+func scanMatchGlobClass(pattern string, start int, inBraces bool) (int, string) {
+	unclosed := func() string {
+		return fmt.Sprintf("Glob pattern character class has no closing ']' for opening '[' at index %d. Either add a closing ']' or use '\\[' to match a literal '['.", start)
+	}
+
+	members := 0
+	rangeLo := rune(-1)  // last member, candidate range start; -1 when none
+	pendingDash := false // saw "<member>-" and the range end is still open
+	member := func(r rune) string {
+		if pendingDash {
+			if rangeLo > r {
+				return fmt.Sprintf("Invalid range '%c-%c' in glob pattern character class.", rangeLo, r)
+			}
+			pendingDash = false
+			rangeLo = -1
+		} else {
+			rangeLo = r
+		}
+		members++
+		return ""
+	}
+
+	i := start + 1
+	// '!' and '^' are ASCII, so the byte test needs no rune decoding.
+	if i < len(pattern) && (pattern[i] == '!' || pattern[i] == '^') {
+		i++
+	}
+	for i < len(pattern) {
+		r, size := utf8.DecodeRuneInString(pattern[i:])
+		switch r {
+		case '\\':
+			i += size
+			if i >= len(pattern) {
+				return 0, unclosed()
+			}
+			esc, escSize := utf8.DecodeRuneInString(pattern[i:])
+			if msg := member(esc); msg != "" {
+				return 0, msg
+			}
+			i += escSize
+			continue
+		case ']':
+			if members == 0 {
+				return 0, fmt.Sprintf("Glob pattern character class at index %d must have at least one character in it.", start)
+			}
+			return i + size, ""
+		case '[':
+			return 0, fmt.Sprintf("Glob pattern character class does not support the unescaped '[' at index %d. Use '\\[' to match '['.", i)
+		case '{':
+			return 0, unclosed()
+		case '}':
+			if !inBraces {
+				return 0, bareClosingBraceMessage(i)
+			}
+			return 0, unclosed()
+		case ',':
+			if inBraces {
+				return 0, unclosed()
+			}
+			if msg := member(r); msg != "" {
+				return 0, msg
+			}
+		case '-':
+			if rangeLo >= 0 && !pendingDash {
+				pendingDash = true
+			} else if msg := member(r); msg != "" {
+				return 0, msg
+			}
+		default:
+			if msg := member(r); msg != "" {
+				return 0, msg
+			}
+		}
+		i += size
+	}
+	return 0, unclosed()
+}
+
+func bareClosingBraceMessage(index int) string {
+	return fmt.Sprintf("Glob pattern brace expansion closing '}' at index %d has no previous opening '{'. Use '\\}' to match a literal '}'.", index)
+}

--- a/fakestorage/matchglob_test.go
+++ b/fakestorage/matchglob_test.go
@@ -1,0 +1,246 @@
+package fakestorage
+
+import "testing"
+
+// The patterns and messages in this table were captured from live GCS
+// (JSON API, 2026-08-24/25). want is "" for patterns that GCS accepts.
+func TestInvalidMatchGlobMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			"empty pattern",
+			"",
+			"",
+		},
+		{
+			"valid baseline",
+			"test/*.jpg",
+			"",
+		},
+		{
+			"unclosed char class",
+			"test/[abc.jpg",
+			"Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"lone open bracket at end",
+			"test/[",
+			"Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"unclosed brace",
+			"test/{a,b.jpg",
+			"Glob pattern brace expansion opening '{' at index 5 has no closing '}'. Use '\\{' to match a literal '{'.",
+		},
+		{
+			"lone open brace",
+			"test/{",
+			"Glob pattern brace expansion opening '{' at index 5 has no closing '}'. Use '\\{' to match a literal '{'.",
+		},
+		{
+			"nested unclosed brace reports the innermost",
+			"test/{a,{b",
+			"Glob pattern brace expansion opening '{' at index 8 has no closing '}'. Use '\\{' to match a literal '{'.",
+		},
+		{
+			"empty char class",
+			"test/[].jpg",
+			"Glob pattern character class at index 5 must have at least one character in it.",
+		},
+		{
+			"negated empty class",
+			"test/[!].jpg",
+			"Glob pattern character class at index 5 must have at least one character in it.",
+		},
+		{
+			"caret-negated empty class",
+			"test/[^].jpg",
+			"Glob pattern character class at index 5 must have at least one character in it.",
+		},
+		{
+			"no POSIX first-bracket-is-literal rule",
+			"test/[]a].jpg",
+			"Glob pattern character class at index 5 must have at least one character in it.",
+		},
+		{
+			"bare closing bracket",
+			"test/a].jpg",
+			"Glob pattern had closing character class ']' at index 6 without any previous opening '['. Either add an opening '[' or use '\\]' to match ']'.",
+		},
+		{
+			"bare closing brace",
+			"test/a}.jpg",
+			"Glob pattern brace expansion closing '}' at index 6 has no previous opening '{'. Use '\\}' to match a literal '}'.",
+		},
+		{
+			"reversed range in class",
+			"test/[z-a].jpg",
+			"Invalid range 'z-a' in glob pattern character class.",
+		},
+		{
+			"unescaped open bracket inside class",
+			"test/[[].jpg",
+			"Glob pattern character class does not support the unescaped '[' at index 6. Use '\\[' to match '['.",
+		},
+		{
+			"unescaped open brace inside class",
+			"test/[{].jpg",
+			"Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"full brace expansion inside class",
+			"test/[{a}].jpg",
+			"Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"closing brace inside class, no brace open",
+			"test/[}].jpg",
+			"Glob pattern brace expansion closing '}' at index 6 has no previous opening '{'. Use '\\}' to match a literal '}'.",
+		},
+		{
+			"unclosed class then closing brace, no brace open",
+			"test/[ab}.jpg",
+			"Glob pattern brace expansion closing '}' at index 8 has no previous opening '{'. Use '\\}' to match a literal '}'.",
+		},
+		{
+			"closing brace inside class aborts the class when a brace is open",
+			"test/{a,[}]}.jpg",
+			"Glob pattern character class has no closing ']' for opening '[' at index 8. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"comma inside class aborts the class when a brace is open",
+			"test/{[a,b]}.jpg",
+			"Glob pattern character class has no closing ']' for opening '[' at index 6. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"index is a byte offset",
+			"é[abc",
+			"Glob pattern character class has no closing ']' for opening '[' at index 2. Either add a closing ']' or use '\\[' to match a literal '['.",
+		},
+		{
+			"trailing backslash is accepted",
+			`test/a\`,
+			"",
+		},
+		{
+			"nested braces",
+			"test/{a,{b,c}}.jpg",
+			"",
+		},
+		{
+			"slash inside class",
+			"test/[a/b].jpg",
+			"",
+		},
+		{
+			"escape of ordinary char",
+			`test/\a.jpg`,
+			"",
+		},
+		{
+			"dash at class end",
+			"test/[a-].jpg",
+			"",
+		},
+		{
+			"dash at class start",
+			"test/[-a].jpg",
+			"",
+		},
+		{
+			"escaped closing bracket inside class",
+			`test/[a\]b].jpg`,
+			"",
+		},
+		{
+			"escaped opening brace needs no close",
+			`test/\{a.jpg`,
+			"",
+		},
+		{
+			"range with escaped endpoint",
+			`test/[\a-b].jpg`,
+			"",
+		},
+		{
+			"well-formed class in brace arm",
+			"test/{a,[b]}.jpg",
+			"",
+		},
+		{
+			"comma in class outside braces",
+			"test/[a,b].jpg",
+			"",
+		},
+		{
+			"comma outside braces",
+			"test/a,b.jpg",
+			"",
+		},
+		{
+			"class of single escaped bracket",
+			`test/[\]].jpg`,
+			"",
+		},
+		{
+			"invalid UTF-8 byte is accepted",
+			"test/\xff.jpg",
+			"",
+		},
+		{
+			"invalid UTF-8 byte inside class",
+			"test/[\xff].jpg",
+			"",
+		},
+		{
+			"range between invalid bytes is accepted, both decode to U+FFFD",
+			"test/[\xff-\xfe].jpg",
+			"",
+		},
+		{
+			"unpaired surrogate encoding is accepted",
+			"test/\xed\xa0\x80.jpg",
+			"",
+		},
+		{
+			"lone continuation byte is accepted",
+			"test/\xb1.jpg",
+			"",
+		},
+		{
+			"ascending multibyte range",
+			"test/[α-ω].jpg",
+			"",
+		},
+		{
+			"reversed multibyte range compares by code point",
+			"test/[ω-α].jpg",
+			"Invalid range 'ω-α' in glob pattern character class.",
+		},
+		{
+			"range from invalid byte to ASCII is reversed after replacement",
+			"test/[\xff-a].jpg",
+			"Invalid range '�-a' in glob pattern character class.",
+		},
+		{
+			"range from ASCII to invalid byte ascends after replacement",
+			"test/[a-\xff].jpg",
+			"",
+		},
+		{
+			"class of single escaped multibyte member",
+			`test/[\é].jpg`,
+			"",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := invalidMatchGlobMessage(test.pattern); got != test.want {
+				t.Errorf("invalidMatchGlobMessage(%q)\ngot:  %q\nwant: %q", test.pattern, got, test.want)
+			}
+		})
+	}
+}

--- a/fakestorage/object.go
+++ b/fakestorage/object.go
@@ -696,6 +696,13 @@ func (s *Server) listObjects(r *http.Request) jsonResponse {
 			errorMessage: "When listing with a glob pattern, the only supported delimiter is '/'.",
 		}
 	}
+	// GCS checks the delimiter before it checks the pattern itself.
+	if msg := invalidMatchGlobMessage(matchGlob); msg != "" {
+		return jsonResponse{
+			status:       http.StatusBadRequest,
+			errorMessage: msg,
+		}
+	}
 	response, err := s.ListObjectsWithOptionsPaginated(bucketName, ListOptions{
 		Prefix:                   r.URL.Query().Get("prefix"),
 		MatchGlob:                matchGlob,

--- a/fakestorage/object_test.go
+++ b/fakestorage/object_test.go
@@ -1391,6 +1391,20 @@ func TestServiceClientListObjectsMatchGlobInvalidDelimiter(t *testing.T) {
 	})
 }
 
+func TestServiceClientListObjectsMatchGlobInvalidPattern(t *testing.T) {
+	runServersTest(t, runServersOptions{objs: getObjectsForListTests()}, func(t *testing.T, server *Server) {
+		query := &storage.Query{MatchGlob: "img/[abc.jpg"}
+		iter := server.Client().Bucket("some-bucket").Objects(context.TODO(), query)
+		_, err := iter.Next()
+		if err == nil || err == iterator.Done {
+			t.Fatalf("expected an error for matchGlob %q, got %v", query.MatchGlob, err)
+		}
+		if !strings.Contains(err.Error(), "no closing ']' for opening '[' at index 4") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestServerClientListAfterCreate(t *testing.T) {
 	for _, versioningEnabled := range []bool{true, false} {
 		for _, withOverwrites := range []bool{true, false} {


### PR DESCRIPTION
Follow-up to #2328, first of the two asked for in the review: on invalid globs, GCS returns a 400, while the emulator returned a 200 (`doublestar.MatchUnvalidated` never rejects a pattern).

## What GCS actually rejects

I probed the live JSON API (2026-08-24/25, 47 patterns) to capture the exact contract. Validation is request-level, so the probes are read-only and need no fixture objects. The rules:

- `\` escapes the next character anywhere. A trailing `\` is **accepted**.
- `]` or `}` without a matching opener is an error.
- Braces must balance and may nest. An unclosed `{` reports the innermost one.
- A character class must be closed and must have at least one member. A leading `!` or `^` negates the class and does not count as a member. There is no POSIX first-`]`-is-literal rule: `[]a]` is an empty-class error.
- Inside a class, `[` and `{` must be escaped. So must `}`, and `,` while a brace expansion is open; unescaped, they abort the class with an unclosed-class error.
- Ranges inside a class must be ascending and compare by code point: `[z-a]` and `[ω-α]` are errors (the message renders the runes), `[a-]` and `[-a]` are literal dashes.
- Patterns need not be valid UTF-8. GCS decodes invalid bytes to U+FFFD, exactly as Go's `utf8.DecodeRuneInString` does: `[\xFF-\xFE]` is accepted as an equal-endpoint range, `[\xFF-a]` is rejected with the replacement character rendered in the message (`Invalid range '�-a'`).
- Index positions in the messages are byte offsets into the pattern (probed with a 2-byte character before the defect).
- The delimiter check (`matchGlob` with a delimiter other than `/`) runs before pattern validation.

Several of these diverge from `doublestar.ValidatePattern` (doublestar rejects a trailing `\` and accepts a bare `]`, `}`, or `[[]`), so the validator implements the probed contract directly rather than borrowing doublestar's.

## What this PR does

- Adds `invalidMatchGlobMessage`, a single-pass scanner that returns GCS's error message verbatim for an invalid pattern (it returns the wire-message string rather than an `error` because the capitalized, period-terminated GCS strings are meant for the response body, not for Go error chains).
- Wires it into `listObjects` after the existing delimiter check, matching the live precedence.
- Tests: a table test with every probed pattern and its captured message, plus a client-level test asserting the 400 surfaces through `cloud.google.com/go/storage`.

Scope: JSON API only, like the feature itself. The XML API has no glob parameter and the gRPC list does not implement `match_glob`.

## Evidence

Replaying all 47 probes against this branch produces **byte-identical status and message** to live GCS on every one — including byte-offset indices and the U+FFFD replacement character in range messages.

Method: live outputs captured with `probe-invalid.sh` and `probe-invalid-utf8.sh` below against a bucket I own; emulator outputs with `emu-invalid-probe.sh` and `emu-utf8-probe.sh` against this branch; compared per-probe on (status, error message).

<details>
<summary>Live GCS output = emulator output (36 probes)</summary>

```text
### V0. valid baseline
glob: test/*.jpg
HTTP 200

### I1. unclosed char class
glob: test/[abc.jpg
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\[' to match a literal '['.

### I2. unclosed brace
glob: test/{a,b.jpg
HTTP 400
error 400 (invalid): Glob pattern brace expansion opening '{' at index 5 has no closing '}'. Use '\{' to match a literal '{'.

### I3. trailing backslash
glob: test/a\
HTTP 200

### I4. empty char class
glob: test/[].jpg
HTTP 400
error 400 (invalid): Glob pattern character class at index 5 must have at least one character in it.

### I5. negated empty class
glob: test/[!].jpg
HTTP 400
error 400 (invalid): Glob pattern character class at index 5 must have at least one character in it.

### I6. bare closing bracket (valid?)
glob: test/a].jpg
HTTP 400
error 400 (invalid): Glob pattern had closing character class ']' at index 6 without any previous opening '['. Either add an opening '[' or use '\]' to match ']'.

### I7. bare closing brace (valid?)
glob: test/a}.jpg
HTTP 400
error 400 (invalid): Glob pattern brace expansion closing '}' at index 6 has no previous opening '{'. Use '\}' to match a literal '}'.

### I8. nested braces
glob: test/{a,{b,c}}.jpg
HTTP 200

### I9. slash inside class
glob: test/[a/b].jpg
HTTP 200

### I10. lone open brace
glob: test/{
HTTP 400
error 400 (invalid): Glob pattern brace expansion opening '{' at index 5 has no closing '}'. Use '\{' to match a literal '{'.

### I11. escape of ordinary char
glob: test/\a.jpg
HTTP 200

### I12. reversed range in class
glob: test/[z-a].jpg
HTTP 400
error 400 (invalid): Invalid range 'z-a' in glob pattern character class.

### I13. lone open bracket at end
glob: test/[
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\[' to match a literal '['.

### I14. empty matchGlob param
glob: 
HTTP 200

### E1. invalid glob AND invalid delimiter (precedence)
glob: test/[abc   delimiter: -
HTTP 400
error 400 (invalid): When listing with a glob pattern, the only supported delimiter is '/'.

### E2. caret empty class
glob: test/[^].jpg
HTTP 400
error 400 (invalid): Glob pattern character class at index 5 must have at least one character in it.

### E3. dash at class end
glob: test/[a-].jpg
HTTP 200

### E4. dash at class start
glob: test/[-a].jpg
HTTP 200

### E5. nested unclosed brace (index?)
glob: test/{a,{b
HTTP 400
error 400 (invalid): Glob pattern brace expansion opening '{' at index 8 has no closing '}'. Use '\{' to match a literal '{'.

### E6. escaped ] inside class
glob: test/[a\]b].jpg
HTTP 200

### E7. [ inside class (literal?)
glob: test/[[].jpg
HTTP 400
error 400 (invalid): Glob pattern character class does not support the unescaped '[' at index 6. Use '\[' to match '['.

### E8. POSIX []a] form
glob: test/[]a].jpg
HTTP 400
error 400 (invalid): Glob pattern character class at index 5 must have at least one character in it.

### E9. escaped { needs no close
glob: test/\{a.jpg
HTTP 200

### E10. class inside brace with }
glob: test/{a,[}]}.jpg
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 8. Either add a closing ']' or use '\[' to match a literal '['.

### E11. range with escape endpoint
glob: test/[\a-b].jpg
HTTP 200

### E12. unclosed class then bare }
glob: test/[ab}.jpg
HTTP 400
error 400 (invalid): Glob pattern brace expansion closing '}' at index 8 has no previous opening '{'. Use '\}' to match a literal '}'.

### F1. comma inside class inside brace
glob: test/{[a,b]}.jpg
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 6. Either add a closing ']' or use '\[' to match a literal '['.

### F2. well-formed class in brace arm
glob: test/{a,[b]}.jpg
HTTP 200

### F3. } in class, no brace open
glob: test/[}].jpg
HTTP 400
error 400 (invalid): Glob pattern brace expansion closing '}' at index 6 has no previous opening '{'. Use '\}' to match a literal '}'.

### F4. { in class, no brace open
glob: test/[{].jpg
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\[' to match a literal '['.

### F5. full brace inside class
glob: test/[{a}].jpg
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 5. Either add a closing ']' or use '\[' to match a literal '['.

### F6. comma in class outside braces
glob: test/[a,b].jpg
HTTP 200

### F7. class of single escaped ]
glob: test/[\]].jpg
HTTP 200

### F8. comma outside braces
glob: test/a,b.jpg
HTTP 200

### X1. multibyte index (bytes)
glob: é[abc
HTTP 400
error 400 (invalid): Glob pattern character class has no closing ']' for opening '[' at index 2. Either add a closing ']' or use '\[' to match a literal '['.
```

</details>

<details>
<summary>UTF-8 probes: live GCS output = emulator output (11 probes)</summary>

```text
### U1. invalid byte 0xFF mid-pattern
encoded glob: test%2F%FF.jpg
HTTP 200

### U2. invalid byte 0xFF alone
encoded glob: %FF
HTTP 200

### U3. invalid byte inside class
encoded glob: test%2F%5B%FF%5D.jpg
HTTP 200

### U4. range between invalid bytes
encoded glob: test%2F%5B%FF-%FE%5D.jpg
HTTP 200

### U5. ascending multibyte range [alpha-omega]
encoded glob: test%2F%5B%CE%B1-%CF%89%5D.jpg
HTTP 200

### U6. DISCRIMINATOR reversed multibyte range [omega-alpha]
encoded glob: test%2F%5B%CF%89-%CE%B1%5D.jpg
HTTP 400
error 400 (invalid): "Invalid range 'ω-α' in glob pattern character class."

### U7. unpaired surrogate encoding ED A0 80
encoded glob: test%2F%ED%A0%80.jpg
HTTP 200

### U8. lone continuation byte 0xB1
encoded glob: test%2F%B1.jpg
HTTP 200

### U9. range invalid-byte to 'a' (reversed after U+FFFD replacement)
encoded glob: test%2F%5B%FF-a%5D.jpg
HTTP 400
error 400 (invalid): "Invalid range '�-a' in glob pattern character class."

### U10. range 'a' to invalid byte (ascending after replacement)
encoded glob: test%2F%5Ba-%FF%5D.jpg
HTTP 200

### U11. class of single escaped multibyte member
encoded glob: test%2F%5B%5C%C3%A9%5D.jpg
HTTP 200
```

</details>

<details>
<summary><code>probe-invalid.sh</code> — capture the live contract (read-only)</summary>

```bash
#!/usr/bin/env bash
# Probe which matchGlob patterns real GCS rejects (JSON API), and with
# what status and message. Validation is request-level: no fixture
# objects are needed and nothing is written. Read-only.
# Usage: GCS_BUCKET=<bucket-you-own> probe-invalid.sh
set -euo pipefail

BUCKET="${GCS_BUCKET:?set GCS_BUCKET to a bucket you own}"
TOKEN="$(gcloud auth print-access-token)"
URL="https://storage.googleapis.com/storage/v1/b/$BUCKET/o"

probe() {
    local label="$1" pattern="$2" delim="${3:-}"
    local args=(-G -s -w '\nHTTP %{http_code}' "$URL"
        --data-urlencode "matchGlob=$pattern"
        --data-urlencode "prefix=test/glob-contract/none/"
        --data-urlencode "fields=items(name)"
        -H "Authorization: Bearer $TOKEN")
    [ -n "$delim" ] && args+=(--data-urlencode "delimiter=$delim")
    local out code
    out="$(curl "${args[@]}")"
    code="$(printf '%s' "$out" | tail -1)"
    if [ -n "$delim" ]; then
        printf '### %s\nglob: %s   delimiter: %s\n%s\n' "$label" "$pattern" "$delim" "$code"
    else
        printf '### %s\nglob: %s\n%s\n' "$label" "$pattern" "$code"
    fi
    if [ "$code" != "HTTP 200" ]; then
        printf '%s\n' "$out" | sed '$d' | python3 -c "import sys, json; d = json.load(sys.stdin); e = d.get('error', {}); print('error %s (%s): %s' % (e.get('code'), (e.get('errors') or [{}])[0].get('reason'), e.get('message', '')))" 2>/dev/null \
            || printf '%s\n' "$out" | head -5
    fi
    printf '\n'
}

echo "date: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
echo "purpose: which matchGlob patterns does GCS reject, and how"
echo

probe "V0. valid baseline"                 'test/*.jpg'
probe "I1. unclosed char class"            'test/[abc.jpg'
probe "I2. unclosed brace"                 'test/{a,b.jpg'
probe "I3. trailing backslash"             'test/a\'
probe "I4. empty char class"               'test/[].jpg'
probe "I5. negated empty class"            'test/[!].jpg'
probe "I6. bare closing bracket (valid?)"  'test/a].jpg'
probe "I7. bare closing brace (valid?)"    'test/a}.jpg'
probe "I8. nested braces"                  'test/{a,{b,c}}.jpg'
probe "I9. slash inside class"             'test/[a/b].jpg'
probe "I10. lone open brace"               'test/{'
probe "I11. escape of ordinary char"       'test/\a.jpg'
probe "I12. reversed range in class"       'test/[z-a].jpg'
probe "I13. lone open bracket at end"      'test/['
probe "I14. empty matchGlob param"         ''
probe "E1. invalid glob AND invalid delimiter (precedence)" 'test/[abc' '-'
probe "E2. caret empty class"                'test/[^].jpg'
probe "E3. dash at class end"                'test/[a-].jpg'
probe "E4. dash at class start"              'test/[-a].jpg'
probe "E5. nested unclosed brace (index?)"   'test/{a,{b'
probe "E6. escaped ] inside class"           'test/[a\]b].jpg'
probe "E7. [ inside class (literal?)"        'test/[[].jpg'
probe "E8. POSIX []a] form"                  'test/[]a].jpg'
probe "E9. escaped { needs no close"         'test/\{a.jpg'
probe "E10. class inside brace with }"       'test/{a,[}]}.jpg'
probe "E11. range with escape endpoint"      'test/[\a-b].jpg'
probe "E12. unclosed class then bare }"      'test/[ab}.jpg'
probe "F1. comma inside class inside brace"   'test/{[a,b]}.jpg'
probe "F2. well-formed class in brace arm"    'test/{a,[b]}.jpg'
probe "F3. } in class, no brace open"         'test/[}].jpg'
probe "F4. { in class, no brace open"         'test/[{].jpg'
probe "F5. full brace inside class"           'test/[{a}].jpg'
probe "F6. comma in class outside braces"     'test/[a,b].jpg'
probe "F7. class of single escaped ]"         'test/[\]].jpg'
probe "F8. comma outside braces"              'test/a,b.jpg'
probe "X1. multibyte index (bytes)"           'é[abc'
```

</details>

<details>
<summary><code>emu-invalid-probe.sh</code> — replay against a fake-gcs-server binary</summary>

```bash
#!/usr/bin/env bash
# Replay the three live invalid-glob probe rounds against a fake-gcs-server
# binary, emitting the same output format for a direct diff.
set -euo pipefail
BIN="${1:?binary}" PORT="${2:?port}"
BUCKET="probe-bucket"
URL="http://localhost:$PORT/storage/v1/b/$BUCKET/o"

"$BIN" -scheme http -port "$PORT" -backend memory -filesystem-root '' >/dev/null 2>&1 &
SRV=$!
trap 'kill $SRV 2>/dev/null || true' EXIT
for _ in $(seq 1 50); do
    curl -fs "http://localhost:$PORT/_internal/healthcheck" >/dev/null 2>&1 && break
    sleep 0.1
done
curl -fs -X POST "http://localhost:$PORT/storage/v1/b?project=p" \
    -H 'Content-Type: application/json' -d "{\"name\": \"$BUCKET\"}" >/dev/null

probe() {
    local label="$1" pattern="$2" delim="${3:-}"
    local args=(-G -s -w '\nHTTP %{http_code}' "$URL"
        --data-urlencode "matchGlob=$pattern"
        --data-urlencode "prefix=test/glob-contract/none/"
        --data-urlencode "fields=items(name)")
    [ -n "$delim" ] && args+=(--data-urlencode "delimiter=$delim")
    local out code
    out="$(curl "${args[@]}")"
    code="$(printf '%s' "$out" | tail -1)"
    if [ -n "$delim" ]; then
        printf '### %s\nglob: %s   delimiter: %s\n%s\n' "$label" "$pattern" "$delim" "$code"
    else
        printf '### %s\nglob: %s\n%s\n' "$label" "$pattern" "$code"
    fi
    if [ "$code" != "HTTP 200" ]; then
        printf '%s\n' "$out" | sed '$d' | python3 -c "import sys, json; d = json.load(sys.stdin); e = d.get('error', {}); print('error %s (%s): %s' % (e.get('code'), (e.get('errors') or [{}])[0].get('reason'), e.get('message', '')))" 2>/dev/null \
            || printf '%s\n' "$out" | head -5
    fi
    printf '\n'
}

probe "V0. valid baseline"                 'test/*.jpg'
probe "I1. unclosed char class"            'test/[abc.jpg'
probe "I2. unclosed brace"                 'test/{a,b.jpg'
probe "I3. trailing backslash"             'test/a\'
probe "I4. empty char class"               'test/[].jpg'
probe "I5. negated empty class"            'test/[!].jpg'
probe "I6. bare closing bracket (valid?)"  'test/a].jpg'
probe "I7. bare closing brace (valid?)"    'test/a}.jpg'
probe "I8. nested braces"                  'test/{a,{b,c}}.jpg'
probe "I9. slash inside class"             'test/[a/b].jpg'
probe "I10. lone open brace"               'test/{'
probe "I11. escape of ordinary char"       'test/\a.jpg'
probe "I12. reversed range in class"       'test/[z-a].jpg'
probe "I13. lone open bracket at end"      'test/['
probe "I14. empty matchGlob param"         ''
probe "E1. invalid glob AND invalid delimiter (precedence)" 'test/[abc' '-'
probe "E2. caret empty class"                'test/[^].jpg'
probe "E3. dash at class end"                'test/[a-].jpg'
probe "E4. dash at class start"              'test/[-a].jpg'
probe "E5. nested unclosed brace (index?)"   'test/{a,{b'
probe "E6. escaped ] inside class"           'test/[a\]b].jpg'
probe "E7. [ inside class (literal?)"        'test/[[].jpg'
probe "E8. POSIX []a] form"                  'test/[]a].jpg'
probe "E9. escaped { needs no close"         'test/\{a.jpg'
probe "E10. class inside brace with }"       'test/{a,[}]}.jpg'
probe "E11. range with escape endpoint"      'test/[\a-b].jpg'
probe "E12. unclosed class then bare }"      'test/[ab}.jpg'
probe "F1. comma inside class inside brace"   'test/{[a,b]}.jpg'
probe "F2. well-formed class in brace arm"    'test/{a,[b]}.jpg'
probe "F3. } in class, no brace open"         'test/[}].jpg'
probe "F4. { in class, no brace open"         'test/[{].jpg'
probe "F5. full brace inside class"           'test/[{a}].jpg'
probe "F6. comma in class outside braces"     'test/[a,b].jpg'
probe "F7. class of single escaped ]"         'test/[\]].jpg'
probe "F8. comma outside braces"              'test/a,b.jpg'
probe "X1. multibyte index (bytes)"           'é[abc'
```

</details>

<details>
<summary><code>probe-invalid-utf8.sh</code> — UTF-8 probes against live GCS (read-only)</summary>

```bash
#!/usr/bin/env bash
# Probe live GCS matchGlob handling of invalid UTF-8 and multibyte
# ranges. Patterns are sent pre-percent-encoded so raw bytes survive.
# Read-only: validation is request-level, no fixture objects needed.
# Usage: GCS_BUCKET=<bucket-you-own> probe-invalid-utf8.sh
set -euo pipefail
BUCKET="${GCS_BUCKET:?set GCS_BUCKET to a bucket you own}"
TOKEN="$(gcloud auth print-access-token)"
URL="https://storage.googleapis.com/storage/v1/b/$BUCKET/o"

probe() {
    local label="$1" encoded="$2"
    local out code
    out="$(curl -G -s -w '\nHTTP %{http_code}' "$URL" \
        -d "matchGlob=$encoded" \
        -d "prefix=test%2Fglob-contract%2Fnone%2F" \
        -d "fields=items(name)" \
        -H "Authorization: Bearer $TOKEN")"
    code="$(printf '%s' "$out" | tail -1)"
    printf '### %s\nencoded glob: %s\n%s\n' "$label" "$encoded" "$code"
    if [ "$code" != "HTTP 200" ]; then
        printf '%s\n' "$out" | sed '$d' | python3 -c "import sys, json; d = json.load(sys.stdin); e = d.get('error', {}); print('error %s (%s): %r' % (e.get('code'), (e.get('errors') or [{}])[0].get('reason'), e.get('message', '')))" 2>/dev/null \
            || printf '%s\n' "$out" | head -5
    fi
    printf '\n'
}

echo "date: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
echo

probe "U1. invalid byte 0xFF mid-pattern"       'test%2F%FF.jpg'
probe "U2. invalid byte 0xFF alone"             '%FF'
probe "U3. invalid byte inside class"           'test%2F%5B%FF%5D.jpg'
probe "U4. range between invalid bytes"         'test%2F%5B%FF-%FE%5D.jpg'
probe "U5. ascending multibyte range [alpha-omega]" 'test%2F%5B%CE%B1-%CF%89%5D.jpg'
probe "U6. DISCRIMINATOR reversed multibyte range [omega-alpha]" 'test%2F%5B%CF%89-%CE%B1%5D.jpg'
probe "U7. unpaired surrogate encoding ED A0 80" 'test%2F%ED%A0%80.jpg'
probe "U8. lone continuation byte 0xB1"          'test%2F%B1.jpg'
probe "U9. range invalid-byte to 'a' (reversed after U+FFFD replacement)" 'test%2F%5B%FF-a%5D.jpg'
probe "U10. range 'a' to invalid byte (ascending after replacement)"      'test%2F%5Ba-%FF%5D.jpg'
probe "U11. class of single escaped multibyte member"                     'test%2F%5B%5C%C3%A9%5D.jpg'
```

</details>

<details>
<summary><code>emu-utf8-probe.sh</code> — replay against a fake-gcs-server binary</summary>

```bash
#!/usr/bin/env bash
# Replay the UTF-8 matchGlob probes against a fake-gcs-server binary.
# Patterns are sent pre-percent-encoded so raw bytes survive.
# Usage: emu-utf8-probe.sh <binary> <port>
set -euo pipefail
BIN="${1:?binary}" PORT="${2:?port}"
BUCKET="probe-bucket"
URL="http://localhost:$PORT/storage/v1/b/$BUCKET/o"

"$BIN" -scheme http -port "$PORT" -backend memory -filesystem-root '' >/dev/null 2>&1 &
SRV=$!
trap 'kill $SRV 2>/dev/null || true' EXIT
for _ in $(seq 1 50); do
    curl -fs "http://localhost:$PORT/_internal/healthcheck" >/dev/null 2>&1 && break
    sleep 0.1
done
curl -fs -X POST "http://localhost:$PORT/storage/v1/b?project=p" \
    -H 'Content-Type: application/json' -d "{\"name\": \"$BUCKET\"}" >/dev/null

probe() {
    local label="$1" encoded="$2"
    local out code
    out="$(curl -G -s -w '\nHTTP %{http_code}' "$URL" \
        -d "matchGlob=$encoded" \
        -d "prefix=test%2Fglob-contract%2Fnone%2F" \
        -d "fields=items(name)")"
    code="$(printf '%s' "$out" | tail -1)"
    printf '### %s\nencoded glob: %s\n%s\n' "$label" "$encoded" "$code"
    if [ "$code" != "HTTP 200" ]; then
        printf '%s\n' "$out" | sed '$d' | python3 -c "import sys, json; d = json.load(sys.stdin); e = d.get('error', {}); print('error %s (%s): %r' % (e.get('code'), (e.get('errors') or [{}])[0].get('reason'), e.get('message', '')))" 2>/dev/null \
            || printf '%s\n' "$out" | head -5
    fi
    printf '\n'
}

probe "U1. invalid byte 0xFF mid-pattern"       'test%2F%FF.jpg'
probe "U2. invalid byte 0xFF alone"             '%FF'
probe "U3. invalid byte inside class"           'test%2F%5B%FF%5D.jpg'
probe "U4. range between invalid bytes"         'test%2F%5B%FF-%FE%5D.jpg'
probe "U5. ascending multibyte range [alpha-omega]" 'test%2F%5B%CE%B1-%CF%89%5D.jpg'
probe "U6. DISCRIMINATOR reversed multibyte range [omega-alpha]" 'test%2F%5B%CF%89-%CE%B1%5D.jpg'
probe "U7. unpaired surrogate encoding ED A0 80" 'test%2F%ED%A0%80.jpg'
probe "U8. lone continuation byte 0xB1"          'test%2F%B1.jpg'
probe "U9. range invalid-byte to 'a' (reversed after U+FFFD replacement)" 'test%2F%5B%FF-a%5D.jpg'
probe "U10. range 'a' to invalid byte (ascending after replacement)"      'test%2F%5Ba-%FF%5D.jpg'
probe "U11. class of single escaped multibyte member"                     'test%2F%5B%5C%C3%A9%5D.jpg'
```

</details>
