### PR TITLE
Support gRPC over the plaintext (-scheme http) listener

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/net v0.58.0 // indirect
+	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/fsouza/fake-gcs-server/internal/config"
 	"github.com/fsouza/fake-gcs-server/internal/grpc"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 func createListener(logger *slog.Logger, cfg *config.Config, scheme string) (net.Listener, *fakestorage.Options) {
@@ -86,16 +88,21 @@ func startServer(logger *slog.Logger, cfg *config.Config) {
 
 	grpcServer := grpc.NewServerWithBackend(httpServer.Backend())
 
+	routingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(
+			r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpServer.HTTPHandler().ServeHTTP(w, r)
+		}
+	})
+	// h2c lets the plaintext listener accept HTTP/2 cleartext (grpc) connections
+	// while still serving HTTP/1.1 (the JSON API) unmodified.
+	h2cHandler := h2c.NewHandler(routingHandler, &http2.Server{})
+
 	for _, listenerAndOpts := range listenersAndOpts {
 		go func(listener net.Listener) {
-			http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.ProtoMajor == 2 && strings.HasPrefix(
-					r.Header.Get("Content-Type"), "application/grpc") {
-					grpcServer.ServeHTTP(w, r)
-				} else {
-					httpServer.HTTPHandler().ServeHTTP(w, r)
-				}
-			}))
+			http.Serve(listener, h2cHandler)
 		}(listenerAndOpts.listener)
 
 		logger.Info(fmt.Sprintf("server started at %s://%s:%d",


### PR DESCRIPTION
Fixes #2345

## Problem
Running with `-scheme http` (or the `-port-http` listener under `-scheme both`) breaks gRPC — see #2345 for the full root-cause writeup.

## Fix
Wraps the plaintext listener's routing handler with `golang.org/x/net/http2/h2c`, adding HTTP/2-cleartext support while still transparently serving HTTP/1.1 (the JSON API) unchanged. The TLS listener is untouched — it already gets HTTP/2 via ALPN. `golang.org/x/net` was already an indirect dependency (via grpc/otel); this promotes it to direct.

No test added — this code path (`startServer`'s scheme/transport handling) has no existing test coverage in the repo today, so this change doesn't introduce a new gap.

## Testing
- `go build ./...`, `go vet ./...`, `go test -race -vet all -mod readonly ./...` all pass.
- Manually verified `grpcurl -plaintext` against the built binary with `-scheme http`.

---
*This PR description was drafted with AI assistance (Claude).*