### PR TITLE
fix(fakestorage): return a descriptive error when uploading to a missing bucket

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -151,7 +151,10 @@ func (s *Server) insertObject(r *http.Request) jsonResponse {
 	bucketName := unescapeMuxVars(mux.Vars(r))["bucketName"]
 
 	if _, err := s.backend.GetBucket(bucketName); err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+		return jsonResponse{
+			status:       http.StatusNotFound,
+			errorMessage: fmt.Sprintf("The specified bucket '%s' does not exist.", bucketName),
+		}
 	}
 	uploadType := r.URL.Query().Get("uploadType")
 	if uploadType == "" && r.Header.Get("X-Goog-Upload-Protocol") == uploadTypeResumable {
@@ -194,7 +197,10 @@ func (s *Server) handleBodyBasedResumableUpload(r *http.Request, body *resumable
 
 	// Check if the bucket exists
 	if _, err := s.backend.GetBucket(bucketName); err != nil {
-		return jsonResponse{status: http.StatusNotFound}
+		return jsonResponse{
+			status:       http.StatusNotFound,
+			errorMessage: fmt.Sprintf("The specified bucket '%s' does not exist.", bucketName),
+		}
 	}
 
 	// Parse customTime if present

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -697,6 +697,44 @@ func TestServerClientObjectWriterBucketNotFound(t *testing.T) {
 	})
 }
 
+func TestServerClientUploadBucketNotFoundMessage(t *testing.T) {
+	server := NewServer(nil)
+	defer server.Stop()
+	server.CreateBucketWithOpts(CreateBucketOpts{Name: "existing-bucket"})
+
+	req, err := http.NewRequest("POST", server.URL()+"/upload/storage/v1/b/missing-bucket/o?uploadType=media&name=some/object.txt", strings.NewReader("data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusNotFound, resp.StatusCode)
+	}
+
+	var body errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	wantMessage := "The specified bucket 'missing-bucket' does not exist."
+	if body.Error.Message != wantMessage {
+		t.Errorf("wrong error message\nwant %q\ngot  %q", wantMessage, body.Error.Message)
+	}
+	if len(body.Error.Errors) == 0 || body.Error.Errors[0].Reason != "notFound" {
+		t.Errorf("wrong error reason\nwant %q\ngot  %+v", "notFound", body.Error.Errors)
+	}
+}
+
 func TestServerClientSimpleUpload(t *testing.T) {
 	server := NewServer(nil)
 	defer server.Stop()


### PR DESCRIPTION
Small follow up to #1753. Uploading an object to a bucket that doesn't exist returned a bare 404 whose message was just "Not Found", which left a few people in that thread unsure what was actually wrong.

This includes the bucket name in the error and follows the wording GCS itself uses ("The specified bucket ... does not exist."), matching the style of the existing "already exists" message in bucket.go. It covers both the regular upload path and the JSON body based resumable upload. Added an HTTP level test that asserts the 404 message and the notFound reason.

Happy to adjust the wording or drop the bucket name if you'd rather mirror GCS exactly.