### PR TITLE
fix(fakestorage): honor X-Upload-Content-Type on resumable uploads

### DIFF
--- a/fakestorage/upload.go
+++ b/fakestorage/upload.go
@@ -33,6 +33,7 @@ const (
 	cacheControlHeader       = "Cache-Control"
 	contentDispositionHeader = "Content-Disposition"
 	contentLanguageHeader    = "Content-Language"
+	uploadContentTypeHeader  = "X-Upload-Content-Type"
 )
 
 const (
@@ -622,6 +623,18 @@ func (s *Server) resumableUpload(bucketName string, r *http.Request) jsonRespons
 		// Use the zero-valued metadata; object name comes from query param "name".
 		if err != nil && err != io.EOF {
 			return jsonResponse{errorMessage: err.Error()}
+		}
+	}
+	// The JSON API also accepts the content type through a request header:
+	// https://cloud.google.com/storage/docs/json_api/v1/parameters#xuploadcontenttype
+	if uploadContentType := r.Header.Get(uploadContentTypeHeader); uploadContentType != "" {
+		if metadata.ContentType == "" {
+			metadata.ContentType = uploadContentType
+		} else if metadata.ContentType != uploadContentType {
+			return jsonResponse{
+				status:       http.StatusBadRequest,
+				errorMessage: fmt.Sprintf("Content-Type specified in the upload (%s) does not match Content-Type specified in metadata (%s).", uploadContentType, metadata.ContentType),
+			}
 		}
 	}
 	objName := r.URL.Query().Get("name")

--- a/fakestorage/upload_test.go
+++ b/fakestorage/upload_test.go
@@ -1993,6 +1993,124 @@ func TestResumableUploadContentType(t *testing.T) {
 			}
 		})
 
+		// The JSON API accepts the content type as the X-Upload-Content-Type
+		// header on session initiation:
+		// https://cloud.google.com/storage/docs/json_api/v1/parameters#xuploadcontenttype
+		t.Run("content type from X-Upload-Content-Type header is honored", func(t *testing.T) {
+			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+			client := server.HTTPClient()
+			const contentType = "image/png"
+			const objectName = "test-content-type-upload-header"
+
+			initReq, err := http.NewRequest("POST", server.URL()+"/upload/storage/v1/b/"+bucketName+"/o?uploadType=resumable&name="+objectName, strings.NewReader("{}"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			initReq.Header.Set("Content-Type", "application/json")
+			initReq.Header.Set("X-Upload-Content-Type", contentType)
+			initResp, err := client.Do(initReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer initResp.Body.Close()
+			if initResp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusOK, initResp.StatusCode)
+			}
+
+			uploadURL := initResp.Header.Get("Location")
+			uploadReq, err := http.NewRequest("PUT", uploadURL, strings.NewReader("test content"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			uploadResp, err := client.Do(uploadReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer uploadResp.Body.Close()
+			if uploadResp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusOK, uploadResp.StatusCode)
+			}
+
+			obj, err := server.GetObject(bucketName, objectName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if obj.ContentType != contentType {
+				t.Errorf("wrong content type\nwant %q\ngot  %q", contentType, obj.ContentType)
+			}
+		})
+
+		// The real GCS backend takes no side on precedence: it rejects the
+		// initiation with a 400 ("Content-Type specified in the upload does not
+		// match Content-Type specified in metadata") when the header and the
+		// session metadata disagree.
+		t.Run("mismatched X-Upload-Content-Type and session metadata content type is rejected", func(t *testing.T) {
+			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+			client := server.HTTPClient()
+			const objectName = "test-content-type-mismatch"
+
+			initReq, err := http.NewRequest("POST", server.URL()+"/upload/storage/v1/b/"+bucketName+"/o?uploadType=resumable&name="+objectName, strings.NewReader(`{"contentType": "text/csv"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			initReq.Header.Set("Content-Type", "application/json")
+			initReq.Header.Set("X-Upload-Content-Type", "image/png")
+			initResp, err := client.Do(initReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer initResp.Body.Close()
+			if initResp.StatusCode != http.StatusBadRequest {
+				t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusBadRequest, initResp.StatusCode)
+			}
+		})
+
+		// The real GCS backend accepts equal values in the header and the
+		// session metadata.
+		t.Run("matching X-Upload-Content-Type and session metadata content type is accepted", func(t *testing.T) {
+			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
+			client := server.HTTPClient()
+			const contentType = "image/png"
+			const objectName = "test-content-type-match"
+
+			initReq, err := http.NewRequest("POST", server.URL()+"/upload/storage/v1/b/"+bucketName+"/o?uploadType=resumable&name="+objectName, strings.NewReader(`{"contentType": "`+contentType+`"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			initReq.Header.Set("Content-Type", "application/json")
+			initReq.Header.Set("X-Upload-Content-Type", contentType)
+			initResp, err := client.Do(initReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer initResp.Body.Close()
+			if initResp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusOK, initResp.StatusCode)
+			}
+
+			uploadURL := initResp.Header.Get("Location")
+			uploadReq, err := http.NewRequest("PUT", uploadURL, strings.NewReader("test content"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			uploadResp, err := client.Do(uploadReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer uploadResp.Body.Close()
+			if uploadResp.StatusCode != http.StatusOK {
+				t.Errorf("wrong status code\nwant %d\ngot  %d", http.StatusOK, uploadResp.StatusCode)
+			}
+
+			obj, err := server.GetObject(bucketName, objectName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if obj.ContentType != contentType {
+				t.Errorf("wrong content type\nwant %q\ngot  %q", contentType, obj.ContentType)
+			}
+		})
+
 		t.Run("multi-chunk upload preserves content type", func(t *testing.T) {
 			server.CreateBucketWithOpts(CreateBucketOpts{Name: bucketName})
 			client := server.HTTPClient()


### PR DESCRIPTION
Fixes #1098

## Problem

The resumable upload session initiation only reads the object's content type from the JSON metadata body. The JSON API also accepts it through the [`X-Upload-Content-Type`](https://cloud.google.com/storage/docs/json_api/v1/parameters#xuploadcontenttype) request header, which fake-gcs-server never reads.

That header is the only place some clients put it: the Cloud Storage Node.js SDK moves `contentType` out of the metadata body into the header on session initiation:

https://github.com/googleapis/google-cloud-node/blob/eb506c06e2e71d92ba58e12a5463473e1e92ae13/handwritten/storage/src/resumable-upload.ts#L814-L817

Any resumable upload through it — the default transport for `bucket.upload()` / `file.createWriteStream()` — is therefore stored as `application/octet-stream` no matter which `contentType` the caller provides, as reported in the comments of https://github.com/fsouza/fake-gcs-server/issues/1098#issuecomment-2295367530.

## Behavior verified against the real GCS backend

Raw HTTP calls (no SDK) against a real bucket:

| Session initiation | Real GCS | fake-gcs-server before | after |
| --- | --- | --- | --- |
| `X-Upload-Content-Type` only | header applied | `application/octet-stream` | header applied |
| header and body metadata equal | accepted, type applied | body applied | accepted, type applied |
| header and body metadata differ | **400** "Content-Type specified in the upload (…) does not match Content-Type specified in metadata (…)" | body silently applied | **400** |

## Changes

- `resumableUpload` falls back to `X-Upload-Content-Type` when the session metadata carries no content type, and rejects the initiation with a 400 when both are present and disagree — matching the real backend.
- Non-regression tests for the three rows above, next to the existing `TestResumableUploadContentType` subtests (all still green, `go test ./...` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
